### PR TITLE
[Hemdi] Radio Component 생성

### DIFF
--- a/src/components/common/RadioGroup/index.tsx
+++ b/src/components/common/RadioGroup/index.tsx
@@ -1,16 +1,16 @@
 import {
   useMemo,
-  FormEvent,
   ReactNode,
   useContext,
   createContext,
+  ChangeEvent,
   PropsWithChildren,
 } from 'react';
 
 type RadioState = {
   name: string;
   selectedValue: string;
-  onChange: (e: FormEvent<HTMLInputElement>) => void;
+  onChange: (e: ChangeEvent<HTMLInputElement>) => void;
 };
 
 const RadioGroupContext = createContext<RadioState>({

--- a/src/components/common/RadioGroup/index.tsx
+++ b/src/components/common/RadioGroup/index.tsx
@@ -91,16 +91,6 @@ const Option = ({
   );
 };
 
-type TitleProps = {
-  id?: string;
-  children: ReactNode;
-};
-
-const Title = ({ children, ...props }: TitleProps) => (
-  <div {...props}>{children}</div>
-);
-
 RadioGroup.Option = Option;
-RadioGroup.Title = Title;
 
 export default RadioGroup;

--- a/src/components/common/RadioGroup/index.tsx
+++ b/src/components/common/RadioGroup/index.tsx
@@ -1,0 +1,101 @@
+import {
+  useMemo,
+  FormEvent,
+  ReactNode,
+  useContext,
+  createContext,
+} from 'react';
+
+type RadioState = {
+  name: string;
+  selectedValue: string;
+  onChange: (e: FormEvent<HTMLInputElement>) => void;
+};
+
+const RadioGroupContext = createContext<RadioState>({
+  name: '',
+  selectedValue: '',
+  onChange: () => {},
+});
+
+const useRadioContext = () => {
+  const context = useContext(RadioGroupContext);
+  if (context === undefined) {
+    throw new Error('useMyContext should be used within MyContext.Provider');
+  }
+  return context;
+};
+
+type RadioGroupProps = RadioState & {
+  children: ReactNode;
+};
+
+type RadioGroupChildren = {
+  Title: React.FC<TitleProps>;
+  Option: React.FC<OptionProps>;
+};
+
+const RadioGroup: React.FC<RadioGroupProps> & RadioGroupChildren = ({
+  name,
+  children,
+  onChange,
+  selectedValue,
+  ...props
+}) => {
+  const values = useMemo(
+    () => ({ name, selectedValue, onChange }),
+    [name, selectedValue, onChange],
+  );
+
+  return (
+    <RadioGroupContext.Provider value={values}>
+      <div {...props}>{children}</div>
+    </RadioGroupContext.Provider>
+  );
+};
+
+type OptionProps = {
+  id?: string;
+  value: string;
+  children: ReactNode;
+  disabled?: boolean;
+};
+
+const Option: React.FC<OptionProps> = ({
+  id,
+  value,
+  children,
+  disabled,
+  ...props
+}) => {
+  const { name, selectedValue, onChange } = useRadioContext();
+  const optionId = id || `option-${name}-${value}`;
+  return (
+    <div {...props}>
+      <input
+        type="radio"
+        name={name}
+        id={optionId}
+        value={value}
+        disabled={disabled}
+        onChange={onChange}
+        checked={value === selectedValue}
+      />
+      <label htmlFor={optionId}>{children}</label>
+    </div>
+  );
+};
+
+type TitleProps = {
+  id?: string;
+  children: ReactNode;
+};
+
+const Title: React.FC<TitleProps> = ({ children, ...props }) => (
+  <div {...props}>{children}</div>
+);
+
+RadioGroup.Option = Option;
+RadioGroup.Title = Title;
+
+export default RadioGroup;

--- a/src/components/common/RadioGroup/index.tsx
+++ b/src/components/common/RadioGroup/index.tsx
@@ -13,16 +13,14 @@ type RadioState = {
   onChange: (e: ChangeEvent<HTMLInputElement>) => void;
 };
 
-const RadioGroupContext = createContext<RadioState>({
-  name: '',
-  selectedValue: '',
-  onChange: () => {},
-});
+const RadioGroupContext = createContext<RadioState | null>(null);
 
 const useRadioContext = () => {
   const context = useContext(RadioGroupContext);
-  if (context === undefined) {
-    throw new Error('useMyContext should be used within MyContext.Provider');
+  if (!context) {
+    throw new Error(
+      'useRadioContext should be used within RadioGroupContext.Provider',
+    );
   }
   return context;
 };

--- a/src/components/common/RadioGroup/index.tsx
+++ b/src/components/common/RadioGroup/index.tsx
@@ -13,6 +13,7 @@ interface RadioState {
 }
 
 const RadioGroupContext = createContext<RadioState | null>(null);
+RadioGroupContext.displayName = 'RadioGroupContext';
 
 const useRadioContext = () => {
   const context = useContext(RadioGroupContext);

--- a/src/components/common/RadioGroup/index.tsx
+++ b/src/components/common/RadioGroup/index.tsx
@@ -57,25 +57,33 @@ const RadioGroup = ({
 
 type OptionProps = {
   id?: string;
+  name?: string;
   value: string;
   children: ReactNode;
   disabled?: boolean;
-  name?: string;
   onChange?: (e: ChangeEvent<HTMLInputElement>) => void;
 };
 
-const Option = ({ id, value, children, disabled, ...props }: OptionProps) => {
-  const { name, selectedValue, onChange } = useRadioContext();
+const Option = ({
+  id,
+  name,
+  value,
+  children,
+  onChange,
+  disabled,
+  ...restProps
+}: OptionProps) => {
+  const { selectedValue } = useRadioContext();
   const optionId = id || `option-${name}-${value}`;
   return (
-    <div {...props}>
+    <div {...restProps}>
       <input
         type="radio"
-        name={name}
         id={optionId}
+        name={name}
         value={value}
-        disabled={disabled}
         onChange={onChange}
+        disabled={disabled}
         checked={value === selectedValue}
       />
       <label htmlFor={optionId}>{children}</label>

--- a/src/components/common/RadioGroup/index.tsx
+++ b/src/components/common/RadioGroup/index.tsx
@@ -4,6 +4,7 @@ import {
   ReactNode,
   useContext,
   createContext,
+  PropsWithChildren,
 } from 'react';
 
 type RadioState = {
@@ -26,22 +27,15 @@ const useRadioContext = () => {
   return context;
 };
 
-type RadioGroupProps = RadioState & {
-  children: ReactNode;
-};
+type RadioGroupProps = PropsWithChildren<RadioState>;
 
-type RadioGroupChildren = {
-  Title: React.FC<TitleProps>;
-  Option: React.FC<OptionProps>;
-};
-
-const RadioGroup: React.FC<RadioGroupProps> & RadioGroupChildren = ({
+const RadioGroup = ({
   name,
   children,
   onChange,
   selectedValue,
   ...props
-}) => {
+}: RadioGroupProps) => {
   const values = useMemo(
     () => ({ name, selectedValue, onChange }),
     [name, selectedValue, onChange],
@@ -61,13 +55,7 @@ type OptionProps = {
   disabled?: boolean;
 };
 
-const Option: React.FC<OptionProps> = ({
-  id,
-  value,
-  children,
-  disabled,
-  ...props
-}) => {
+const Option = ({ id, value, children, disabled, ...props }: OptionProps) => {
   const { name, selectedValue, onChange } = useRadioContext();
   const optionId = id || `option-${name}-${value}`;
   return (
@@ -91,7 +79,7 @@ type TitleProps = {
   children: ReactNode;
 };
 
-const Title: React.FC<TitleProps> = ({ children, ...props }) => (
+const Title = ({ children, ...props }: TitleProps) => (
   <div {...props}>{children}</div>
 );
 

--- a/src/components/common/RadioGroup/radioGroup.stories.tsx
+++ b/src/components/common/RadioGroup/radioGroup.stories.tsx
@@ -1,0 +1,39 @@
+import { ComponentStory, ComponentMeta } from '@storybook/react';
+import { useState } from 'react';
+
+import RadioGroup from '.';
+
+import StyledRadio from './radioGroup.styled';
+
+export default {
+  title: 'common/RadioGroup',
+  component: RadioGroup,
+} as ComponentMeta<typeof RadioGroup>;
+
+export const Default: ComponentStory<typeof RadioGroup> = () => {
+  const [selectedValue, setValue] = useState('velog');
+
+  const handleOnChange = (e) => {
+    setValue(e.target.value);
+  };
+
+  const dataList = [
+    { value: 'velog', label: 'Velog' },
+    { value: 'tistory', label: 'Tistory' },
+    { value: 'notion', label: 'Notion' },
+  ];
+
+  return (
+    <StyledRadio.Group
+      name="FirstGroup"
+      selectedValue={selectedValue}
+      onChange={handleOnChange}
+    >
+      {dataList.map(({ value, label }) => (
+        <StyledRadio.Option key={value} value={value}>
+          {label}
+        </StyledRadio.Option>
+      ))}
+    </StyledRadio.Group>
+  );
+};

--- a/src/components/common/RadioGroup/radioGroup.styled.tsx
+++ b/src/components/common/RadioGroup/radioGroup.styled.tsx
@@ -1,33 +1,55 @@
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 
 import RadioGroup from '@components/common/RadioGroup';
 
 const StyledRadioGroup = styled(RadioGroup)`
-  min-width: 580px;
-`;
-
-const StyleRadioTitle = styled(RadioGroup.Title)`
-  padding-bottom: 10px;
-  font-size: 13px;
-`;
-
-const StyledOptionWrapper = styled.div`
   display: flex;
-  gap: 20px;
+  flex-direction: row;
+  width: 355px;
+  justify-content: space-between;
+  align-items: center;
+`;
+
+const CustomRadioButtonStyle = css`
+  -webkit-appearance: none;
+  appearance: none;
+  width: 32px;
+  height: 32px;
+  margin: 0;
+  padding: 6px;
+  border: 2px solid #0000007f;
+  border-radius: 50%;
+  background-clip: content-box;
+
+  :checked {
+    background-color: #007aff;
+    :hover {
+      background-color: #007aff;
+    }
+  }
+
+  :hover {
+    background-color: #85c0fe;
+  }
 `;
 
 const StyledRadioOption = styled(RadioGroup.Option)`
   display: flex;
   align-items: center;
-  gap: 5px;
-  font-size: 12px;
+
+  input[type='radio'] {
+    ${CustomRadioButtonStyle}
+  }
+
+  label {
+    font-size: 17px;
+    padding: 10px;
+  }
 `;
 
 const StyledRadio = {
   Group: StyledRadioGroup,
-  Title: StyleRadioTitle,
   Option: StyledRadioOption,
-  OptionWrapper: StyledOptionWrapper,
 };
 
 export default StyledRadio;

--- a/src/components/common/RadioGroup/radioGroup.styled.tsx
+++ b/src/components/common/RadioGroup/radioGroup.styled.tsx
@@ -1,0 +1,33 @@
+import styled from 'styled-components';
+
+import RadioGroup from '@components/common/RadioGroup';
+
+const StyledRadioGroup = styled(RadioGroup)`
+  min-width: 580px;
+`;
+
+const StyleRadioTitle = styled(RadioGroup.Title)`
+  padding-bottom: 10px;
+  font-size: 13px;
+`;
+
+const StyledOptionWrapper = styled.div`
+  display: flex;
+  gap: 20px;
+`;
+
+const StyledRadioOption = styled(RadioGroup.Option)`
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  font-size: 12px;
+`;
+
+const StyledRadio = {
+  Group: StyledRadioGroup,
+  Title: StyleRadioTitle,
+  Option: StyledRadioOption,
+  OptionWrapper: StyledOptionWrapper,
+};
+
+export default StyledRadio;


### PR DESCRIPTION
close #19 

![RadioGroup exam](https://user-images.githubusercontent.com/34249911/192448218-011560ba-288a-46d8-aee6-3b420b2819a3.PNG)

## 🤔 구현하면서 고민한 사항

<details>
<summary><h3>1. Headless 설계<h3></summary>

![스크린샷 2022-09-23 오전 8 48 29](https://user-images.githubusercontent.com/34249911/192456944-3b8b90fa-c1c5-452d-bdc5-8f5f0e51db29.png)
#### RadioGroup 컴포넌트는 무엇을 하는 컴포넌트인가?
- 그룹을 대표하는 **Title**을 가지고 있다.
- 그룹으로 묶인 **라디오 버튼(Option)** 들을 가지고 있다.
    - 각 버튼들은 **어떤 옵션인지에 대한 설명(label)** 을 가지고 있다.
- 상태값으로 **선택된 옵션**이라는 값을 다룬다.

#### 컴포넌트 사용자가 할 수 있는 기능은?
- Title을 원하는 위치에 추가하여 수정하거나 제거 할 수 있다.
- Option을 추가할 수 있다.
- Option의 label을 사용자가 자유롭게 추가 할 수 있게 구현.
- Option 선택 시의 이벤트(onChange) 를 추가할 수 있고, 해당 이벤트 핸들러를 통해 선택된 옵션을 가져올 수 있음.

#### UI 사용자가 할 수 있는 기능은?
- UI 사용자는 마우스로 라디오 버튼 그룹의 옵션들 중 하나를 선택할 수 있다.

</details>
<details>
<summary><h3>2. Optional Id</h3></summary>

```tsx
const Option: React.FC<RadioOptionProps> = ({ id , ...props}) => {
  const { name, selectedValue, onChange } = useRadioContext();
  const optionId = id || `option-${name}-${value}`;  // 요기
  return (
    <div {...props}>
      <input
        type="radio"
        name={name}
        id={optionId}
        ...
      />
      <label htmlFor={optionId}>{children}</label>
    </div>
  );
};
```
Input 과 Label 을 연결하기 위해서는 동일한 id를 반드시 설정해줘야 함.
하지만 각 Option 별로 고유한 value 값도 설정을 하고 있는데 굳이 id를 또 따로 사용자가 입력해주는 건 코드도 복잡해지는 것 같고 번거로운 것 같다고 느낌.
어차피 submit 시에도 name 값이 쓰이니 옵션 별 id의 용도가 단순히 Input 과 Label을 연결하기 위함이라면 어떤 값이든 상관없을 것 같아 Optional로 설정하고 undefined인 경우 임의로 생성(`option-${name}-${value}`)해주는 식으로 구현함.

</details>

## 📢PR을 통해 논의하고 싶은 것!!!
[Headless 컴포넌트의 하위 컴포넌트 타입 지정 방식](https://github.com/Co-Studo/Co-Studo-front/discussions/25)
의논한 내용은 따로 기록하는게 좋을 것 같아 discussion 으로 옮겼습니다!