### PR TITLE
[Jamie] Row, Tab Component 생성

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -35,6 +35,8 @@ module.exports = {
       namedComponents: 'arrow-function'
     }],
     'react/react-in-jsx-scope': 'off',
+    'react/require-default-props': 'off',
+    'react/jsx-no-constructed-context-values': 'off',
     'import/order': ['error', {
       groups: ['builtin', 'external', 'internal', 'index'],
       alphabetize: {

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ node_modules/
 build/
 coverage/
 
+.idea
 .env
 # Local Netlify folder
 .netlify

--- a/src/components/common/Row/index.tsx
+++ b/src/components/common/Row/index.tsx
@@ -1,0 +1,23 @@
+import { ReactNode } from 'react';
+
+import * as S from '@components/common/Row/row.styled';
+
+type RowProps = {
+  title: ReactNode;
+  description: ReactNode;
+  left: ReactNode;
+  right: ReactNode;
+};
+
+const Row = ({ title, description, left, right }: RowProps) => (
+  <S.Container>
+    <S.Box>{left}</S.Box>
+    <S.Main>
+      <S.Box>{title}</S.Box>
+      <S.Box>{description}</S.Box>
+    </S.Main>
+    <S.Box>{right}</S.Box>
+  </S.Container>
+);
+
+export default Row;

--- a/src/components/common/Row/row.stories.tsx
+++ b/src/components/common/Row/row.stories.tsx
@@ -1,0 +1,18 @@
+import { ComponentStory, ComponentMeta } from '@storybook/react';
+
+import Row from '@components/common/Row';
+
+export default {
+  title: 'common/Row',
+  component: Row,
+  args: {
+    title: '제목',
+    description: '설명',
+    left: 'o',
+    right: 'x',
+  },
+} as ComponentMeta<typeof Row>;
+
+export const Default: ComponentStory<typeof Row> = (args) => (
+  <Row {...args} />
+);

--- a/src/components/common/Row/row.styled.tsx
+++ b/src/components/common/Row/row.styled.tsx
@@ -1,0 +1,18 @@
+import styled from 'styled-components';
+
+export const Container = styled.div`
+  display: flex;
+  gap: 8px;
+  width: 100%;
+  max-width: 250px;
+`;
+
+export const Main = styled.div`
+  display: flex;
+  flex-direction: column;
+  flex-grow: 1;
+`;
+
+export const Box = styled.div`
+  display: flex;
+`;

--- a/src/components/common/Tab/index.tsx
+++ b/src/components/common/Tab/index.tsx
@@ -1,0 +1,121 @@
+import {
+  createContext,
+  useState,
+  Dispatch,
+  SetStateAction,
+  useContext,
+  useMemo,
+  Children,
+  cloneElement,
+  FC,
+  ReactNode,
+  ReactElement,
+} from 'react';
+
+type TabState = {
+  activeIndex: number;
+  activateTab: Dispatch<SetStateAction<number>>;
+};
+
+const initState = {
+  activeIndex: 0,
+  activateTab: () => {},
+};
+
+const TabContext = createContext<TabState>(initState);
+TabContext.displayName = 'TabContext';
+
+const useTabContext = () => {
+  const context = useContext(TabContext);
+  if (!context) {
+    throw new Error('useTabContext should be used within TabContext.Provider');
+  }
+  return context;
+};
+
+type TabGroupProps = {
+  defaultIndex?: number;
+  children: ReactNode;
+};
+
+const TabGroup: FC<TabGroupProps> = ({ defaultIndex, children, ...props }) => {
+  const [activeIndex, activateTab] = useState(defaultIndex || 0);
+
+  const value = useMemo(() => ({ activeIndex, activateTab }), [activeIndex]);
+
+  return (
+    <TabContext.Provider value={value}>
+      <div {...props}>{children}</div>
+    </TabContext.Provider>
+  );
+};
+
+type TabListProps = {
+  children: ReactElement[];
+};
+
+const TabList: FC<TabListProps> = ({ children, ...props }) => (
+  <ul {...props}>
+    {Children.map(children, (child, index) =>
+      cloneElement(child, {
+        tabId: index,
+      }),
+    )}
+  </ul>
+);
+
+type TabPropsType = {
+  tabId?: number;
+  children: ReactNode;
+};
+
+const TabRoot: FC<TabPropsType> = ({ tabId, children, ...props }) => {
+  const { activeIndex, activateTab } = useTabContext();
+
+  const isActive = activeIndex === tabId;
+  const handleTabClick = () => tabId !== undefined && activateTab(tabId);
+
+  return (
+    <li {...props} data-selected={isActive}>
+      <button type="button" onClick={handleTabClick}>
+        {children}
+      </button>
+    </li>
+  );
+};
+
+type TabPanelsProps = {
+  children: ReactElement[];
+};
+
+const TabPanels: FC<TabPanelsProps> = ({ children }) => (
+  <>
+    {Children.map(children, (child, index) =>
+      cloneElement(child, {
+        tabId: index,
+      }),
+    )}
+  </>
+);
+
+type TabPanelProps = {
+  tabId?: number;
+  children: ReactNode;
+};
+
+const TabPanel: FC<TabPanelProps> = ({ tabId, children, ...props }) => {
+  const { activeIndex } = useTabContext();
+
+  const isActive = activeIndex === tabId;
+
+  return isActive ? <div {...props}>{children}</div> : null;
+};
+
+const Tab = Object.assign(TabRoot, {
+  Group: TabGroup,
+  List: TabList,
+  Panels: TabPanels,
+  Panel: TabPanel,
+});
+
+export default Tab;

--- a/src/components/common/Tab/index.tsx
+++ b/src/components/common/Tab/index.tsx
@@ -4,10 +4,8 @@ import {
   Dispatch,
   SetStateAction,
   useContext,
-  useMemo,
   Children,
   cloneElement,
-  FC,
   ReactNode,
   ReactElement,
 } from 'react';
@@ -17,12 +15,7 @@ type TabState = {
   activateTab: Dispatch<SetStateAction<number>>;
 };
 
-const initState = {
-  activeIndex: 0,
-  activateTab: () => {},
-};
-
-const TabContext = createContext<TabState>(initState);
+const TabContext = createContext<TabState | null>(null);
 TabContext.displayName = 'TabContext';
 
 const useTabContext = () => {
@@ -38,14 +31,14 @@ type TabGroupProps = {
   children: ReactNode;
 };
 
-const TabGroup: FC<TabGroupProps> = ({ defaultIndex, children, ...props }) => {
+const TabGroup = ({ defaultIndex, children, ...restProps }: TabGroupProps) => {
   const [activeIndex, activateTab] = useState(defaultIndex || 0);
 
-  const value = useMemo(() => ({ activeIndex, activateTab }), [activeIndex]);
+  const value = { activeIndex, activateTab };
 
   return (
     <TabContext.Provider value={value}>
-      <div {...props}>{children}</div>
+      <div {...restProps}>{children}</div>
     </TabContext.Provider>
   );
 };
@@ -54,8 +47,8 @@ type TabListProps = {
   children: ReactElement[];
 };
 
-const TabList: FC<TabListProps> = ({ children, ...props }) => (
-  <ul {...props}>
+const TabList = ({ children, ...restProps }: TabListProps) => (
+  <ul {...restProps}>
     {Children.map(children, (child, index) =>
       cloneElement(child, {
         tabId: index,
@@ -69,14 +62,14 @@ type TabPropsType = {
   children: ReactNode;
 };
 
-const TabRoot: FC<TabPropsType> = ({ tabId, children, ...props }) => {
+const Tab = ({ tabId, children, ...restProps }: TabPropsType) => {
   const { activeIndex, activateTab } = useTabContext();
 
   const isActive = activeIndex === tabId;
   const handleTabClick = () => tabId !== undefined && activateTab(tabId);
 
   return (
-    <li {...props} data-selected={isActive}>
+    <li {...restProps} data-selected={isActive}>
       <button type="button" onClick={handleTabClick}>
         {children}
       </button>
@@ -88,7 +81,7 @@ type TabPanelsProps = {
   children: ReactElement[];
 };
 
-const TabPanels: FC<TabPanelsProps> = ({ children }) => (
+const TabPanels = ({ children }: TabPanelsProps) => (
   <>
     {Children.map(children, (child, index) =>
       cloneElement(child, {
@@ -103,19 +96,17 @@ type TabPanelProps = {
   children: ReactNode;
 };
 
-const TabPanel: FC<TabPanelProps> = ({ tabId, children, ...props }) => {
+const TabPanel = ({ tabId, children, ...restProps }: TabPanelProps) => {
   const { activeIndex } = useTabContext();
 
   const isActive = activeIndex === tabId;
 
-  return isActive ? <div {...props}>{children}</div> : null;
+  return isActive ? <div {...restProps}>{children}</div> : null;
 };
 
-const Tab = Object.assign(TabRoot, {
-  Group: TabGroup,
-  List: TabList,
-  Panels: TabPanels,
-  Panel: TabPanel,
-});
+Tab.Group = TabGroup;
+Tab.List = TabList;
+Tab.Panels = TabPanels;
+Tab.Panel = TabPanel;
 
 export default Tab;

--- a/src/components/common/Tab/tab.a.styled.tsx
+++ b/src/components/common/Tab/tab.a.styled.tsx
@@ -1,0 +1,36 @@
+import styled from 'styled-components';
+
+import Tab from '@components/common/Tab';
+
+const StyledTabList = styled(Tab.List)`
+  display: flex;
+  gap: 20px;
+`;
+
+const StyledTabRoot = styled(Tab)`
+  cursor: pointer;
+  
+  * {
+    font-size: 22px;
+    color: #dfdfdf;
+  }
+  
+  &[data-selected=true] {
+    * {
+      color: #939393;
+    }
+  }
+`;
+
+const StyledTabPanel = styled(Tab.Panel)`
+  color: #939393;
+`;
+
+const StyledTab = Object.assign(StyledTabRoot, {
+  Group: Tab.Group,
+  List: StyledTabList,
+  Panels: Tab.Panels,
+  Panel: StyledTabPanel,
+})
+
+export default StyledTab;

--- a/src/components/common/Tab/tab.b.styled.tsx
+++ b/src/components/common/Tab/tab.b.styled.tsx
@@ -1,0 +1,72 @@
+import styled from 'styled-components';
+
+import Tab from '@components/common/Tab';
+
+const StyledTabGroup = styled(Tab.Group)`
+  width: 100%;
+`;
+
+const StyledTabList = styled(Tab.List)`
+  display: flex;
+  gap: 20px;
+  width: inherit;
+  height: 70px;
+  background-color: #F5F5F5;
+  padding: 0 45px;
+`;
+
+const StyledActiveBar = styled.div`
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  width: inherit;
+  height: 3px;
+  background-color: #007AFF;
+`;
+
+const StyledTabRoot = styled(Tab)`
+  position: relative;
+  display: flex;
+  align-items: center;
+  width: 100px;
+  height: 100%;
+  cursor: pointer;
+
+  & > * {
+    width: 100px;
+    height: 100%;
+    color: #dfdfdf;
+    font-size: 22px;
+  }
+
+  &[data-selected=true] {
+    & > * {
+      color: #000000;
+    }
+  }
+  
+  &:not([data-selected=true]) {
+    & div {
+      display: none;
+    }
+  }
+`;
+
+const StyledTabPanel = styled(Tab.Panel)`
+  width: inherit;
+  min-height: 50vh;
+  background-color: #fff;
+  color: #000000;
+  font-size: 18px;
+  padding: 45px;
+`;
+
+const StyledTab = Object.assign(StyledTabRoot, {
+  Group: StyledTabGroup,
+  List: StyledTabList,
+  Panels: Tab.Panels,
+  Panel: StyledTabPanel,
+  ActiveBar: StyledActiveBar,
+})
+
+export default StyledTab;

--- a/src/components/common/Tab/tab.stories.tsx
+++ b/src/components/common/Tab/tab.stories.tsx
@@ -1,0 +1,42 @@
+import { ComponentStory, ComponentMeta } from '@storybook/react';
+
+import Tab from '@components/common/Tab';
+import StyledTabA from '@components/common/Tab/tab.a.styled';
+import StyledTabB from '@components/common/Tab/tab.b.styled';
+
+export default {
+  title: 'common/Tab',
+  component: Tab,
+} as ComponentMeta<typeof Tab>;
+
+export const TabA: ComponentStory<typeof Tab> = () => (
+  <StyledTabA.Group>
+    <StyledTabA.List>
+      <StyledTabA>Tab A</StyledTabA>
+      <StyledTabA>Tab B</StyledTabA>
+    </StyledTabA.List>
+    <StyledTabA.Panels>
+      <StyledTabA.Panel>TabPanel A</StyledTabA.Panel>
+      <StyledTabA.Panel>TabPanel B</StyledTabA.Panel>
+    </StyledTabA.Panels>
+  </StyledTabA.Group>
+);
+
+export const TabB: ComponentStory<typeof Tab> = () => (
+  <StyledTabB.Group>
+    <StyledTabB.List>
+      <StyledTabB>
+        Tab A
+        <StyledTabB.ActiveBar />
+      </StyledTabB>
+      <StyledTabB>
+        Tab B
+        <StyledTabB.ActiveBar />
+      </StyledTabB>
+    </StyledTabB.List>
+    <StyledTabB.Panels>
+      <StyledTabB.Panel>TabPanel A</StyledTabB.Panel>
+      <StyledTabB.Panel>TabPanel B</StyledTabB.Panel>
+    </StyledTabB.Panels>
+  </StyledTabB.Group>
+)


### PR DESCRIPTION
close #20 

# Tab 컴포넌트

![TabA](https://user-images.githubusercontent.com/62706988/193104040-75b4b5f4-eb9d-4eeb-8cbc-06c17997b4a0.gif)
![TabB](https://user-images.githubusercontent.com/62706988/193104037-2fd4c50f-7389-4b65-9850-a6a67832d5c2.gif)

<details>
<summary><h3>설계</h3></summary>

### 요구사항

- 탭의 목록을 보여준다.
- 마우스로 각 탭을 클릭하여 활성화할 수 있다.
- 활성화된 탭과 활성화되지 않은 탭을 구분할 수 있도록 한다.
- 각 탭에 맞는 컨텐츠가 보여진다.

### 인터페이스

```tsx
<Tab.Group>
  <Tab.List>
    <Tab>Tab A</Tab>
    <Tab>Tab B</Tab>
  </Tab.List>
  <Tab.Panels>
    <Tab.Panel>TabPanel A</Tab.Panel>
    <Tab.Panel>TabPanel B</Tab.Panel>
  </Tab.Panels>
</Tab.Group>
```
</details>
<details>
<summary><h3>구현 & 고민사항</h3></summary>

### 구현

- `Tab.List` 안에 `Tab` 컴포넌트를 나열하여 탭의 목록을 보여준다.
- `Tab.Panels` 안에 `Tab.Panel` 컴포넌트를 나열한다. 각 `Tab.Panel`은 순서에 맞는 `Tab` 컴포넌트와 짝을 이루고, 탭을 누르면 `Tab`과 인덱스가 일치하는 `Tab.Panel` 컴포넌트가 렌더링된다.
- `data-selected` 값을 통해 활성화된 탭과 그렇지 않은 탭을 구분하여 스타일을 적용할 수 있다.
- 프로젝트 내에 탭으로 사용될 수 있는 경우가 두 가지 있는데 스타일이 달라서 일단 임시로 styled 파일을 구분하여 스토리를 작성했다. 추후 분리해서 사용하면 될 것 같다.

### 고민사항

**Tab 컴포넌트 마크업**

탭 부분을 버튼으로 구현해야겠다고 생각하고 있었는데, [때에 따라 링크가 사용될 수도 있다는 글](https://github.com/reactjs/react-tabs/issues/250)을 보게 되었다. 다른 라이브러리들을 살펴보니 버튼을 사용하는 경우도 있고, 링크까지 적용할 수 있도록 하는 경우도 있었다.

- [Material UI](https://github.com/mui/material-ui/blob/master/packages/mui-base/src/TabUnstyled/TabUnstyled.tsx#L49) : 버튼 또는 링크를 적용할 수 있도록 되어있는 것 같다.
- [Headless UI](https://github.com/tailwindlabs/headlessui/blob/main/packages/%40headlessui-react/src/components/tabs/tabs.tsx#L311) : 디폴트로 버튼 태그를 적용하고 있는 것을 보면 다른 태그를 적용하는 것도 가능은 할 것 같다.
- [Radix UI](https://github.com/radix-ui/primitives/blob/main/packages/react/tabs/src/Tabs.tsx#L150) : 버튼을 사용하고 있다.

그렇다면 Tab 컴포넌트 안에 들어가는 요소를 render props 방식으로 받아서 사용하면 어떨까 했는데, 우리 프로젝트에서는 그렇게 사용될 수 있는 여지가 있을까 생각해봤을 때 URL이 변경되어야 하는 경우는 없을 것 같다는 생각이 들어 일단은 버튼을 사용하는 것으로 구현했다.

**Tab ID 부여 방식**

처음 생각했던 방식은 각 탭을 식별하고 탭과 컨텐츠를 연결해줄 수 있는 고유한 값을 사용하는 사람이 지정해줄 수 있도록 하는 것이었는데, 내부에서 활성화된 탭과 패널을 표시하기 위해 필요한 값을 굳이 외부에서 받을 필요는 없다는 생각이 들어서 `Children.map`을 통해 id값을 넣어주는 식으로 구현했다.

이 방식을 사용하면 TabList와 TabPanels 안에 Tab과 TabPanel 컴포넌트가 바로 하위 자식으로 들어와야 한다는 제약이 생기긴 하지만, 구조상 다른 요소가 들어올만한 경우가 없을 것 같아 문제가 없을 것이라고 생각했다.

그리고 id 값으로 숫자 인덱스를 부여하고 있는데, 탭 내부에서 Tab과 TabPanel을 연결짓는 용도로만 쓰는 거라 괜찮지 않을까 싶었다..!

</details>

# Row 컴포넌트

<img width="216" alt="Row 컴포넌트" src="https://user-images.githubusercontent.com/62706988/193102656-d0a6af5f-8237-4b55-aeac-f91bc923a17e.png">

### 구현 & 고민사항

- 전체적인 위치만 잡을 수 있도록 스타일을 작성했다.
- 각 prop을 div로 감싼 이유는 Row 컴포넌트를 사용할 때 props로 꼭 컴포넌트가 들어온다는 보장이 없기 때문이다. 단순히 텍스트만 넣고 싶은 경우도 있을텐데, 텍스트만 들어오게되면 레이아웃이 깨지기 때문에 컴포넌트가 들어오든 텍스트가 들어오든 동일하게 보여질 수 있도록 하는 게 좋다고 생각했다.