### PR TITLE
[Dony] headless Slider component 구현

### DIFF
--- a/src/components/common/Slider/NextButton.tsx
+++ b/src/components/common/Slider/NextButton.tsx
@@ -1,0 +1,45 @@
+import { useSlideIndexContext } from '@components/common/Slider/context/SlideIndexContext';
+
+import { useSliderInfoContext } from '@components/common/Slider/context/SliderInfoContext';
+import throttle from '@utils/eventDelay';
+
+const NextButton = ({ children, ...restProps }) => {
+  const [{ currentIndex }, dispatch] = useSlideIndexContext();
+  const {
+    options: { slidesToShow, slidesToScroll, arrows, speed },
+    SlideLength,
+  } = useSliderInfoContext();
+  const limitIndex = SlideLength - slidesToShow;
+  const disabled = currentIndex >= limitIndex;
+
+  const handleNextButtonClick = () => {
+    if (disabled) return;
+
+    const increasedIndex =
+      currentIndex + slidesToScroll < limitIndex
+        ? slidesToScroll
+        : limitIndex - currentIndex;
+
+    throttle(
+      () =>
+        dispatch({
+          type: 'INCREASE_CURRENT_INDEX',
+          slidesToScroll: increasedIndex,
+        }),
+      speed,
+    );
+  };
+
+  return arrows ? (
+    <button
+      type="button"
+      onClick={handleNextButtonClick}
+      disabled={disabled}
+      {...restProps}
+    >
+      {children}
+    </button>
+  ) : null;
+};
+
+export default NextButton;

--- a/src/components/common/Slider/NextButton.tsx
+++ b/src/components/common/Slider/NextButton.tsx
@@ -14,23 +14,21 @@ const NextButton = ({ children, ...restProps }) => {
   const handleNextButtonClick = () => {
     if (disabled) return;
 
-    throttle(() => {
-      const increasedIndex =
-        currentIndex + slidesToScroll < limitIndex
-          ? slidesToScroll
-          : limitIndex - currentIndex;
+    const increasedIndex =
+      currentIndex + slidesToScroll < limitIndex
+        ? slidesToScroll
+        : limitIndex - currentIndex;
 
-      dispatch({
-        type: 'INCREASE_CURRENT_INDEX',
-        slidesToScroll: increasedIndex,
-      });
-    }, speed);
+    dispatch({
+      type: 'INCREASE_CURRENT_INDEX',
+      slidesToScroll: increasedIndex,
+    });
   };
 
   return (
     <button
       type="button"
-      onClick={handleNextButtonClick}
+      onClick={throttle(handleNextButtonClick, speed)}
       disabled={disabled}
       {...restProps}
     >

--- a/src/components/common/Slider/NextButton.tsx
+++ b/src/components/common/Slider/NextButton.tsx
@@ -1,12 +1,11 @@
 import { useSlideIndexContext } from '@components/common/Slider/context/SlideIndexContext';
-
 import { useSliderInfoContext } from '@components/common/Slider/context/SliderInfoContext';
 import throttle from '@utils/eventDelay';
 
 const NextButton = ({ children, ...restProps }) => {
   const [{ currentIndex }, dispatch] = useSlideIndexContext();
   const {
-    options: { slidesToShow, slidesToScroll, arrows, speed },
+    options: { slidesToShow, slidesToScroll, speed },
     SlideLength,
   } = useSliderInfoContext();
   const limitIndex = SlideLength - slidesToShow;
@@ -30,7 +29,7 @@ const NextButton = ({ children, ...restProps }) => {
     );
   };
 
-  return arrows ? (
+  return (
     <button
       type="button"
       onClick={handleNextButtonClick}
@@ -39,7 +38,7 @@ const NextButton = ({ children, ...restProps }) => {
     >
       {children}
     </button>
-  ) : null;
+  );
 };
 
 export default NextButton;

--- a/src/components/common/Slider/NextButton.tsx
+++ b/src/components/common/Slider/NextButton.tsx
@@ -14,19 +14,17 @@ const NextButton = ({ children, ...restProps }) => {
   const handleNextButtonClick = () => {
     if (disabled) return;
 
-    const increasedIndex =
-      currentIndex + slidesToScroll < limitIndex
-        ? slidesToScroll
-        : limitIndex - currentIndex;
+    throttle(() => {
+      const increasedIndex =
+        currentIndex + slidesToScroll < limitIndex
+          ? slidesToScroll
+          : limitIndex - currentIndex;
 
-    throttle(
-      () =>
-        dispatch({
-          type: 'INCREASE_CURRENT_INDEX',
-          slidesToScroll: increasedIndex,
-        }),
-      speed,
-    );
+      dispatch({
+        type: 'INCREASE_CURRENT_INDEX',
+        slidesToScroll: increasedIndex,
+      });
+    }, speed);
   };
 
   return (

--- a/src/components/common/Slider/PrevButton.tsx
+++ b/src/components/common/Slider/PrevButton.tsx
@@ -13,23 +13,21 @@ const PrevButton = ({ children, ...restProps }) => {
   const handlePrevButtonClick = () => {
     if (disabled) return;
 
-    throttle(() => {
-      const decreasedIndex =
-        currentIndex - slidesToScroll > limitIndex
-          ? slidesToScroll
-          : currentIndex - limitIndex;
+    const decreasedIndex =
+      currentIndex - slidesToScroll > limitIndex
+        ? slidesToScroll
+        : currentIndex - limitIndex;
 
-      dispatch({
-        type: 'DECREASE_CURRENT_INDEX',
-        slidesToScroll: decreasedIndex,
-      });
-    }, speed);
+    dispatch({
+      type: 'DECREASE_CURRENT_INDEX',
+      slidesToScroll: decreasedIndex,
+    });
   };
 
   return (
     <button
       type="button"
-      onClick={handlePrevButtonClick}
+      onClick={throttle(handlePrevButtonClick, speed)}
       disabled={disabled}
       {...restProps}
     >

--- a/src/components/common/Slider/PrevButton.tsx
+++ b/src/components/common/Slider/PrevButton.tsx
@@ -1,12 +1,11 @@
 import { useSlideIndexContext } from '@components/common/Slider/context/SlideIndexContext';
-
 import { useSliderInfoContext } from '@components/common/Slider/context/SliderInfoContext';
 import throttle from '@utils/eventDelay';
 
 const PrevButton = ({ children, ...restProps }) => {
   const [{ currentIndex }, dispatch] = useSlideIndexContext();
   const {
-    options: { slidesToScroll, arrows, speed },
+    options: { slidesToScroll, speed },
   } = useSliderInfoContext();
   const limitIndex = 0;
   const disabled = currentIndex <= limitIndex;
@@ -29,7 +28,7 @@ const PrevButton = ({ children, ...restProps }) => {
     );
   };
 
-  return arrows ? (
+  return (
     <button
       type="button"
       onClick={handlePrevButtonClick}
@@ -38,7 +37,7 @@ const PrevButton = ({ children, ...restProps }) => {
     >
       {children}
     </button>
-  ) : null;
+  );
 };
 
 export default PrevButton;

--- a/src/components/common/Slider/PrevButton.tsx
+++ b/src/components/common/Slider/PrevButton.tsx
@@ -13,19 +13,17 @@ const PrevButton = ({ children, ...restProps }) => {
   const handlePrevButtonClick = () => {
     if (disabled) return;
 
-    const decreasedIndex =
-      currentIndex - slidesToScroll > limitIndex
-        ? slidesToScroll
-        : currentIndex - limitIndex;
+    throttle(() => {
+      const decreasedIndex =
+        currentIndex - slidesToScroll > limitIndex
+          ? slidesToScroll
+          : currentIndex - limitIndex;
 
-    throttle(
-      () =>
-        dispatch({
-          type: 'DECREASE_CURRENT_INDEX',
-          slidesToScroll: decreasedIndex,
-        }),
-      speed,
-    );
+      dispatch({
+        type: 'DECREASE_CURRENT_INDEX',
+        slidesToScroll: decreasedIndex,
+      });
+    }, speed);
   };
 
   return (

--- a/src/components/common/Slider/PrevButton.tsx
+++ b/src/components/common/Slider/PrevButton.tsx
@@ -1,0 +1,44 @@
+import { useSlideIndexContext } from '@components/common/Slider/context/SlideIndexContext';
+
+import { useSliderInfoContext } from '@components/common/Slider/context/SliderInfoContext';
+import throttle from '@utils/eventDelay';
+
+const PrevButton = ({ children, ...restProps }) => {
+  const [{ currentIndex }, dispatch] = useSlideIndexContext();
+  const {
+    options: { slidesToScroll, arrows, speed },
+  } = useSliderInfoContext();
+  const limitIndex = 0;
+  const disabled = currentIndex <= limitIndex;
+
+  const handlePrevButtonClick = () => {
+    if (disabled) return;
+
+    const decreasedIndex =
+      currentIndex - slidesToScroll > limitIndex
+        ? slidesToScroll
+        : currentIndex - limitIndex;
+
+    throttle(
+      () =>
+        dispatch({
+          type: 'DECREASE_CURRENT_INDEX',
+          slidesToScroll: decreasedIndex,
+        }),
+      speed,
+    );
+  };
+
+  return arrows ? (
+    <button
+      type="button"
+      onClick={handlePrevButtonClick}
+      disabled={disabled}
+      {...restProps}
+    >
+      {children}
+    </button>
+  ) : null;
+};
+
+export default PrevButton;

--- a/src/components/common/Slider/Slide.tsx
+++ b/src/components/common/Slider/Slide.tsx
@@ -1,6 +1,6 @@
-import { useSlideIndexContext } from '@components/common/Slider/context/SlideIndexContext';
 import { css } from 'styled-components';
 
+import { useSlideIndexContext } from '@components/common/Slider/context/SlideIndexContext';
 import { useSliderInfoContext } from '@components/common/Slider/context/SliderInfoContext';
 
 const Slide = ({ children, ...restProps }) => {

--- a/src/components/common/Slider/Slide.tsx
+++ b/src/components/common/Slider/Slide.tsx
@@ -1,0 +1,33 @@
+import { useSlideIndexContext } from '@components/common/Slider/context/SlideIndexContext';
+import { css } from 'styled-components';
+
+import { useSliderInfoContext } from '@components/common/Slider/context/SliderInfoContext';
+
+const Slide = ({ children, ...restProps }) => {
+  const [{ currentIndex }] = useSlideIndexContext();
+  const {
+    options: { slidesToShow, slidesMargin, speed },
+  } = useSliderInfoContext();
+
+  return (
+    <li
+      css={css`
+        flex: 0 0 auto;
+        width: calc(
+          100% / ${slidesToShow} -
+            (${slidesMargin} * (${slidesToShow - 1}) / ${slidesToShow})
+        );
+        transform: translate(
+          calc((100% + ${slidesMargin}) * ${-currentIndex}),
+          0
+        );
+        transition: transform calc(${speed}s / 1000) ease-in-out;
+      `}
+      {...restProps}
+    >
+      {children}
+    </li>
+  );
+};
+
+export default Slide;

--- a/src/components/common/Slider/SlideList.tsx
+++ b/src/components/common/Slider/SlideList.tsx
@@ -1,0 +1,23 @@
+import { css } from 'styled-components';
+
+import { useSliderInfoContext } from '@components/common/Slider/context/SliderInfoContext';
+
+const SlideList = ({ children, ...restProps }) => {
+  const {
+    options: { slidesMargin },
+  } = useSliderInfoContext();
+
+  return (
+    <ul
+      css={css`
+        display: flex;
+        gap: ${slidesMargin};
+      `}
+      {...restProps}
+    >
+      {children}
+    </ul>
+  );
+};
+
+export default SlideList;

--- a/src/components/common/Slider/Slider.tsx
+++ b/src/components/common/Slider/Slider.tsx
@@ -1,0 +1,70 @@
+import { ReactElement, useEffect } from 'react';
+import { css } from 'styled-components';
+
+import { SliderOptions } from '@components/common/Slider/context/SliderInfoContext';
+import SliderProvider from '@components/common/Slider/context/SliderProvider';
+import { isNaturalNumber } from '@utils/validation';
+
+type SliderProps = {
+  options?: Partial<SliderOptions>;
+  children: ReactElement | ReactElement[];
+};
+
+const defaultOptions = {
+  slidesToShow: 1,
+  slidesToScroll: 1,
+  slidesMargin: '0px',
+  speed: 1000,
+  initialSlide: 0,
+};
+
+const Slider = ({ options = defaultOptions, children }: SliderProps) => {
+  const sliderOptions = { ...defaultOptions, ...options };
+
+  const validateOptions = () => {
+    const { slidesToShow, slidesToScroll, speed, initialSlide } = options;
+    const optionsToNeedCheck = {
+      slidesToShow,
+      slidesToScroll,
+      speed,
+      initialSlide,
+    };
+
+    Object.keys(optionsToNeedCheck).forEach((key) => {
+      const option = optionsToNeedCheck[key];
+      if (option && !isNaturalNumber(option))
+        throw new Error(
+          `Only natural numbers are allowed for the ${key} option value.`,
+        );
+    });
+  };
+
+  useEffect(() => validateOptions(), [options]);
+
+  const getSlideLength = () => {
+    const Children = Array.isArray(children) ? children : [children];
+    const slideList = Children.find((child) => {
+      if (typeof child.type === 'string') return false;
+      return child?.type.name === 'SlideList';
+    });
+    const SlideLength = slideList ? slideList.props.children.length : 0;
+
+    return SlideLength;
+  };
+
+  return (
+    <SliderProvider options={sliderOptions} SlideLength={getSlideLength()}>
+      <div
+        css={css`
+          position: relative;
+          width: 100%;
+          overflow: hidden;
+        `}
+      >
+        {children}
+      </div>
+    </SliderProvider>
+  );
+};
+
+export default Slider;

--- a/src/components/common/Slider/context/SlideIndexContext.ts
+++ b/src/components/common/Slider/context/SlideIndexContext.ts
@@ -1,6 +1,6 @@
 import { createContext, Dispatch, useContext } from 'react';
 
-type SlideIndexContextValues = {
+type SlideIndexState = {
   currentIndex: number;
 };
 
@@ -9,8 +9,10 @@ type SlideIndexAction = {
   slidesToScroll: number;
 };
 
+type SlideIndexContextValues = [SlideIndexState, Dispatch<SlideIndexAction>];
+
 export const reducer = (
-  { currentIndex }: SlideIndexContextValues,
+  { currentIndex }: SlideIndexState,
   action: SlideIndexAction,
 ) => {
   const { type, slidesToScroll } = action;
@@ -26,9 +28,8 @@ export const reducer = (
 };
 
 export const SlideIndexContext =
-  createContext<[SlideIndexContextValues, Dispatch<SlideIndexAction>] | null>(
-    null,
-  );
+  createContext<SlideIndexContextValues | null>(null);
+SlideIndexContext.displayName = 'SlideIndexContext';
 
 export const useSlideIndexContext = () => {
   const context = useContext(SlideIndexContext);

--- a/src/components/common/Slider/context/SlideIndexContext.ts
+++ b/src/components/common/Slider/context/SlideIndexContext.ts
@@ -1,0 +1,42 @@
+import { createContext, Dispatch, useContext } from 'react';
+
+type SlideIndexContextValues = {
+  currentIndex: number;
+};
+
+type SlideIndexAction = {
+  type: 'INCREASE_CURRENT_INDEX' | 'DECREASE_CURRENT_INDEX';
+  slidesToScroll: number;
+};
+
+export const reducer = (
+  { currentIndex }: SlideIndexContextValues,
+  action: SlideIndexAction,
+) => {
+  const { type, slidesToScroll } = action;
+
+  switch (type) {
+    case 'INCREASE_CURRENT_INDEX':
+      return { currentIndex: currentIndex + slidesToScroll };
+    case 'DECREASE_CURRENT_INDEX':
+      return { currentIndex: currentIndex - slidesToScroll };
+    default:
+      throw new Error(`There is no type '${type}'. Please check the type.`);
+  }
+};
+
+export const SlideIndexContext =
+  createContext<[SlideIndexContextValues, Dispatch<SlideIndexAction>] | null>(
+    null,
+  );
+
+export const useSlideIndexContext = () => {
+  const context = useContext(SlideIndexContext);
+
+  if (!context)
+    throw new Error(
+      'useSlideIndexContext should be used within SlideIndexContext.Provider',
+    );
+
+  return context;
+};

--- a/src/components/common/Slider/context/SliderInfoContext.ts
+++ b/src/components/common/Slider/context/SliderInfoContext.ts
@@ -8,12 +8,14 @@ export type SliderOptions = {
   initialSlide: number;
 };
 
-type SliderInfoState = {
+type SliderInfoContextValue = {
   options: SliderOptions;
   SlideLength: number;
 };
 
-export const SliderInfoContext = createContext<SliderInfoState | null>(null);
+export const SliderInfoContext =
+  createContext<SliderInfoContextValue | null>(null);
+SliderInfoContext.displayName = 'SliderInfoContext';
 
 export const useSliderInfoContext = () => {
   const context = useContext(SliderInfoContext);

--- a/src/components/common/Slider/context/SliderInfoContext.ts
+++ b/src/components/common/Slider/context/SliderInfoContext.ts
@@ -1,0 +1,28 @@
+import { createContext, useContext } from 'react';
+
+export type SliderOptions = {
+  slidesToShow: number;
+  slidesToScroll: number;
+  slidesMargin: string;
+  arrows: boolean;
+  speed: number;
+  initialSlide: number;
+};
+
+type SliderInfoState = {
+  options: SliderOptions;
+  SlideLength: number;
+};
+
+export const SliderInfoContext = createContext<SliderInfoState | null>(null);
+
+export const useSliderInfoContext = () => {
+  const context = useContext(SliderInfoContext);
+
+  if (!context)
+    throw new Error(
+      'useSliderInfoContext should be used within SliderInfoContext.Provider',
+    );
+
+  return context;
+};

--- a/src/components/common/Slider/context/SliderInfoContext.ts
+++ b/src/components/common/Slider/context/SliderInfoContext.ts
@@ -4,7 +4,6 @@ export type SliderOptions = {
   slidesToShow: number;
   slidesToScroll: number;
   slidesMargin: string;
-  arrows: boolean;
   speed: number;
   initialSlide: number;
 };

--- a/src/components/common/Slider/context/SliderProvider.tsx
+++ b/src/components/common/Slider/context/SliderProvider.tsx
@@ -1,4 +1,4 @@
-import { ReactNode, useReducer } from 'react';
+import { ReactElement, useReducer } from 'react';
 
 import {
   reducer,
@@ -12,7 +12,7 @@ import {
 type SliderProviderProps = {
   options: SliderOptions;
   SlideLength: number;
-  children: ReactNode | ReactNode[];
+  children: ReactElement | ReactElement[];
 };
 
 const SliderProvider = ({

--- a/src/components/common/Slider/context/SliderProvider.tsx
+++ b/src/components/common/Slider/context/SliderProvider.tsx
@@ -1,0 +1,41 @@
+import { ReactNode, useReducer } from 'react';
+
+import {
+  reducer,
+  SlideIndexContext,
+} from '@components/common/Slider/context/SlideIndexContext';
+import {
+  SliderOptions,
+  SliderInfoContext,
+} from '@components/common/Slider/context/SliderInfoContext';
+
+type SliderProviderProps = {
+  options: SliderOptions;
+  SlideLength: number;
+  children: ReactNode | ReactNode[];
+};
+
+const SliderProvider = ({
+  options,
+  SlideLength,
+  children,
+}: SliderProviderProps) => {
+  const SliderInfo = {
+    options,
+    SlideLength,
+  };
+
+  const SlideIndexReducer = useReducer(reducer, {
+    currentIndex: options.initialSlide,
+  });
+
+  return (
+    <SliderInfoContext.Provider value={SliderInfo}>
+      <SlideIndexContext.Provider value={SlideIndexReducer}>
+        {children}
+      </SlideIndexContext.Provider>
+    </SliderInfoContext.Provider>
+  );
+};
+
+export default SliderProvider;

--- a/src/components/common/Slider/index.tsx
+++ b/src/components/common/Slider/index.tsx
@@ -11,11 +11,13 @@ import { css } from 'styled-components';
 type SliderOptions = {
   slidesToShow: number;
   slidesToScroll: number;
+  slidesMargin: string;
 };
 
 const defaultSliderOptions = {
   slidesToShow: 1,
   slidesToScroll: 1,
+  slidesMargin: '0px',
 };
 
 type SliderProps = {
@@ -93,7 +95,7 @@ const Slider = ({ options = defaultSliderOptions, children }: SliderProps) => {
 };
 
 const SliderList = ({ children, ...props }) => {
-  const [, dispatch] = useSliderContext();
+  const [{ options }, dispatch] = useSliderContext();
 
   useEffect(() => {
     dispatch({
@@ -106,6 +108,7 @@ const SliderList = ({ children, ...props }) => {
     <ul
       css={css`
         display: flex;
+        gap: ${options.slidesMargin};
       `}
       {...props}
     >
@@ -116,14 +119,20 @@ const SliderList = ({ children, ...props }) => {
 
 const SliderItem = ({ children, ...props }) => {
   const [{ options, currentIndex }] = useSliderContext();
-  const { slidesToShow } = options;
+  const { slidesToShow, slidesMargin } = options;
 
   return (
     <li
       css={css`
         flex: 0 0 auto;
-        width: calc(100% / ${slidesToShow});
-        transform: translate(calc(100% * ${-currentIndex}), 0);
+        width: calc(
+          100% / ${slidesToShow} -
+            (${slidesMargin} * (${slidesToShow - 1}) / ${slidesToShow})
+        );
+        transform: translate(
+          calc((100% + ${slidesMargin}) * ${-currentIndex}),
+          0
+        );
         transition: transform 1s ease-in-out;
       `}
       {...props}

--- a/src/components/common/Slider/index.tsx
+++ b/src/components/common/Slider/index.tsx
@@ -17,7 +17,6 @@ const defaultOptions = {
   slidesToShow: 1,
   slidesToScroll: 1,
   slidesMargin: '0px',
-  arrows: true,
   speed: 1000,
   initialSlide: 0,
 };

--- a/src/components/common/Slider/index.tsx
+++ b/src/components/common/Slider/index.tsx
@@ -8,11 +8,14 @@ import {
 } from 'react';
 import { css } from 'styled-components';
 
+import throttle from '@utils/throttle';
+
 type SliderOptions = {
   slidesToShow: number;
   slidesToScroll: number;
   slidesMargin: string;
   arrows: boolean;
+  speed: number;
 };
 
 const defaultSliderOptions = {
@@ -20,6 +23,7 @@ const defaultSliderOptions = {
   slidesToScroll: 1,
   slidesMargin: '0px',
   arrows: true,
+  speed: 1000,
 };
 
 type SliderProps = {
@@ -121,7 +125,7 @@ const SliderList = ({ children, ...props }) => {
 
 const SliderItem = ({ children, ...props }) => {
   const [{ options, currentIndex }] = useSliderContext();
-  const { slidesToShow, slidesMargin } = options;
+  const { slidesToShow, slidesMargin, speed } = options;
 
   return (
     <li
@@ -135,7 +139,7 @@ const SliderItem = ({ children, ...props }) => {
           calc((100% + ${slidesMargin}) * ${-currentIndex}),
           0
         );
-        transition: transform 1s ease-in-out;
+        transition: transform calc(${speed}s / 1000) ease-in-out;
       `}
       {...props}
     >
@@ -156,7 +160,7 @@ const setCurrentIndex = (
 
 const SliderPrevButton = ({ children, ...props }) => {
   const [{ options, currentIndex }, dispatch] = useSliderContext();
-  const { slidesToScroll, arrows } = options;
+  const { slidesToScroll, arrows, speed } = options;
   const limitIndex = 0;
   const disabled = currentIndex <= limitIndex;
 
@@ -165,7 +169,7 @@ const SliderPrevButton = ({ children, ...props }) => {
 
     const newIndex = currentIndex - slidesToScroll;
 
-    setCurrentIndex(newIndex, dispatch);
+    throttle(() => setCurrentIndex(newIndex, dispatch), speed);
   };
 
   const handlePrevButtonClick = () => {
@@ -186,7 +190,7 @@ const SliderPrevButton = ({ children, ...props }) => {
 
 const SliderNextButton = ({ children, ...props }) => {
   const [{ options, currentIndex, slideLength }, dispatch] = useSliderContext();
-  const { slidesToShow, slidesToScroll, arrows } = options;
+  const { slidesToShow, slidesToScroll, arrows, speed } = options;
   const limitIndex = slideLength - slidesToShow;
   const disabled = currentIndex >= limitIndex;
 
@@ -195,7 +199,7 @@ const SliderNextButton = ({ children, ...props }) => {
 
     const newIndex = currentIndex + slidesToScroll;
 
-    setCurrentIndex(newIndex, dispatch);
+    throttle(() => setCurrentIndex(newIndex, dispatch), speed);
   };
 
   const handleNextButtonClick = () => {

--- a/src/components/common/Slider/index.tsx
+++ b/src/components/common/Slider/index.tsx
@@ -1,0 +1,211 @@
+import {
+  createContext,
+  useContext,
+  Dispatch,
+  useReducer,
+  useEffect,
+  ReactNode,
+} from 'react';
+import { css } from 'styled-components';
+
+type SliderOptions = {
+  slidesToShow: number;
+  slidesToScroll: number;
+};
+
+const defaultSliderOptions = {
+  slidesToShow: 1,
+  slidesToScroll: 1,
+};
+
+type SliderProps = {
+  options?: Partial<SliderOptions>;
+  children: ReactNode;
+};
+
+type SliderContextValues = {
+  options: SliderOptions;
+  currentIndex: number;
+  slideLength: number;
+};
+
+type SliderAction = {
+  type: 'UPDATE_CURRENT_INDEX' | 'SET_SLIDES_LENGTH';
+  payload: Partial<Omit<SliderContextValues, 'options'>>;
+};
+
+const reducer = (state: SliderContextValues, action: SliderAction) => {
+  const { type, payload } = action;
+
+  switch (type) {
+    case 'UPDATE_CURRENT_INDEX':
+      return { ...state, currentIndex: payload.currentIndex };
+    case 'SET_SLIDES_LENGTH':
+      return { ...state, slideLength: payload.slideLength };
+    default:
+      return state;
+  }
+};
+
+const initSliderState = {
+  options: defaultSliderOptions,
+  slideLength: 0,
+  currentIndex: 0,
+};
+
+const SliderContext = createContext<
+  [SliderContextValues, Dispatch<SliderAction>]
+>([initSliderState, () => null]);
+
+const useSliderContext = () => {
+  const context = useContext(SliderContext);
+
+  if (context === undefined)
+    throw new Error(
+      'useSliderContext should be used within SliderContext.Provider',
+    );
+
+  return context;
+};
+
+const Slider = ({ options = defaultSliderOptions, children }: SliderProps) => {
+  const sliderOptions = { ...defaultSliderOptions, ...options };
+  const initState = {
+    options: sliderOptions,
+    currentIndex: 0,
+    slideLength: 0,
+  };
+  const sliderReducer = useReducer(reducer, initState);
+
+  return (
+    <SliderContext.Provider value={sliderReducer}>
+      <div
+        css={css`
+          position: relative;
+          width: 100%;
+          overflow: hidden;
+        `}
+      >
+        {children}
+      </div>
+    </SliderContext.Provider>
+  );
+};
+
+const SliderList = ({ children, ...props }) => {
+  const [, dispatch] = useSliderContext();
+
+  useEffect(() => {
+    dispatch({
+      type: 'SET_SLIDES_LENGTH',
+      payload: { slideLength: children.length },
+    });
+  }, [dispatch, children.length]);
+
+  return (
+    <ul
+      css={css`
+        display: flex;
+      `}
+      {...props}
+    >
+      {children}
+    </ul>
+  );
+};
+
+const SliderItem = ({ children, ...props }) => {
+  const [{ options, currentIndex }] = useSliderContext();
+  const { slidesToShow } = options;
+
+  return (
+    <li
+      css={css`
+        flex: 0 0 auto;
+        width: calc(100% / ${slidesToShow});
+        transform: translate(calc(100% * ${-currentIndex}), 0);
+        transition: transform 1s ease-in-out;
+      `}
+      {...props}
+    >
+      {children}
+    </li>
+  );
+};
+
+const setCurrentIndex = (
+  newIndex: number,
+  dispatch: Dispatch<SliderAction>,
+) => {
+  dispatch({
+    type: 'UPDATE_CURRENT_INDEX',
+    payload: { currentIndex: newIndex },
+  });
+};
+
+const SliderPrevButton = ({ children, ...props }) => {
+  const [{ options, currentIndex }, dispatch] = useSliderContext();
+  const { slidesToScroll } = options;
+  const limitIndex = 0;
+  const disabled = currentIndex <= limitIndex;
+
+  const slideToPrev = () => {
+    if (disabled) return;
+
+    const newIndex = currentIndex - slidesToScroll;
+
+    setCurrentIndex(newIndex, dispatch);
+  };
+
+  const handlePrevButtonClick = () => {
+    slideToPrev();
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={handlePrevButtonClick}
+      disabled={disabled}
+      {...props}
+    >
+      {children}
+    </button>
+  );
+};
+
+const SliderNextButton = ({ children, ...props }) => {
+  const [{ options, currentIndex, slideLength }, dispatch] = useSliderContext();
+  const { slidesToShow, slidesToScroll } = options;
+  const limitIndex = slideLength - slidesToShow;
+  const disabled = currentIndex >= limitIndex;
+
+  const slideToNext = () => {
+    if (disabled) return;
+
+    const newIndex = currentIndex + slidesToScroll;
+
+    setCurrentIndex(newIndex, dispatch);
+  };
+
+  const handleNextButtonClick = () => {
+    slideToNext();
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={handleNextButtonClick}
+      disabled={disabled}
+      {...props}
+    >
+      {children}
+    </button>
+  );
+};
+
+Slider.List = SliderList;
+Slider.Item = SliderItem;
+Slider.PrevButton = SliderPrevButton;
+Slider.NextButton = SliderNextButton;
+
+export default Slider;

--- a/src/components/common/Slider/index.tsx
+++ b/src/components/common/Slider/index.tsx
@@ -49,9 +49,13 @@ const reducer = (state: SliderContextValues, action: SliderAction) => {
 
   switch (type) {
     case 'UPDATE_CURRENT_INDEX':
-      return { ...state, currentIndex: payload.currentIndex };
+      return payload.currentIndex
+        ? { ...state, currentIndex: payload.currentIndex }
+        : state;
     case 'SET_SLIDES_LENGTH':
-      return { ...state, slideLength: payload.slideLength };
+      return payload.slideLength
+        ? { ...state, slideLength: payload.slideLength }
+        : state;
     default:
       return state;
   }

--- a/src/components/common/Slider/index.tsx
+++ b/src/components/common/Slider/index.tsx
@@ -1,4 +1,4 @@
-import { ReactNode } from 'react';
+import { ReactElement } from 'react';
 import { css } from 'styled-components';
 
 import { SliderOptions } from '@components/common/Slider/context/SliderInfoContext';
@@ -10,7 +10,7 @@ import SlideList from '@components/common/Slider/SlideList';
 
 type SliderProps = {
   options?: Partial<SliderOptions>;
-  children: ReactNode | ReactNode[];
+  children: ReactElement | ReactElement[];
 };
 
 const defaultOptions = {

--- a/src/components/common/Slider/index.tsx
+++ b/src/components/common/Slider/index.tsx
@@ -27,12 +27,8 @@ const Slider = ({ options = defaultOptions, children }: SliderProps) => {
   const getSlideLength = () => {
     const Children = Array.isArray(children) ? children : [children];
     const slideList = Children.find((child) => {
-      if (
-        child?.type.name === 'SlideList' ||
-        child?.type.target.name === 'SlideList'
-      )
-        return true;
-      return false;
+      if (typeof child.type === 'string') return false;
+      return child?.type.name === 'SlideList';
     });
     const SlideLength = slideList ? slideList.props.children.length : 0;
 

--- a/src/components/common/Slider/index.tsx
+++ b/src/components/common/Slider/index.tsx
@@ -1,58 +1,14 @@
-import { ReactElement } from 'react';
-import { css } from 'styled-components';
-
-import { SliderOptions } from '@components/common/Slider/context/SliderInfoContext';
-import SliderProvider from '@components/common/Slider/context/SliderProvider';
 import NextButton from '@components/common/Slider/NextButton';
 import PrevButton from '@components/common/Slider/PrevButton';
 import Slide from '@components/common/Slider/Slide';
 import SlideList from '@components/common/Slider/SlideList';
+import SliderRoot from '@components/common/Slider/Slider';
 
-type SliderProps = {
-  options?: Partial<SliderOptions>;
-  children: ReactElement | ReactElement[];
-};
-
-const defaultOptions = {
-  slidesToShow: 1,
-  slidesToScroll: 1,
-  slidesMargin: '0px',
-  speed: 1000,
-  initialSlide: 0,
-};
-
-const Slider = ({ options = defaultOptions, children }: SliderProps) => {
-  const sliderOptions = { ...defaultOptions, ...options };
-
-  const getSlideLength = () => {
-    const Children = Array.isArray(children) ? children : [children];
-    const slideList = Children.find((child) => {
-      if (typeof child.type === 'string') return false;
-      return child?.type.name === 'SlideList';
-    });
-    const SlideLength = slideList ? slideList.props.children.length : 0;
-
-    return SlideLength;
-  };
-
-  return (
-    <SliderProvider options={sliderOptions} SlideLength={getSlideLength()}>
-      <div
-        css={css`
-          position: relative;
-          width: 100%;
-          overflow: hidden;
-        `}
-      >
-        {children}
-      </div>
-    </SliderProvider>
-  );
-};
-
-Slider.List = SlideList;
-Slider.Item = Slide;
-Slider.PrevButton = PrevButton;
-Slider.NextButton = NextButton;
+const Slider = Object.assign(SliderRoot, {
+  List: SlideList,
+  Item: Slide,
+  PrevButton,
+  NextButton,
+});
 
 export default Slider;

--- a/src/components/common/Slider/index.tsx
+++ b/src/components/common/Slider/index.tsx
@@ -8,7 +8,7 @@ import {
 } from 'react';
 import { css } from 'styled-components';
 
-import throttle from '@utils/throttle';
+import throttle from '@utils/eventDelay';
 
 type SliderOptions = {
   slidesToShow: number;
@@ -16,6 +16,7 @@ type SliderOptions = {
   slidesMargin: string;
   arrows: boolean;
   speed: number;
+  initialSlide: number;
 };
 
 const defaultSliderOptions = {
@@ -24,6 +25,7 @@ const defaultSliderOptions = {
   slidesMargin: '0px',
   arrows: true,
   speed: 1000,
+  initialSlide: 0,
 };
 
 type SliderProps = {
@@ -80,7 +82,7 @@ const Slider = ({ options = defaultSliderOptions, children }: SliderProps) => {
   const sliderOptions = { ...defaultSliderOptions, ...options };
   const initState = {
     options: sliderOptions,
-    currentIndex: 0,
+    currentIndex: sliderOptions.initialSlide,
     slideLength: 0,
   };
   const sliderReducer = useReducer(reducer, initState);
@@ -167,7 +169,10 @@ const SliderPrevButton = ({ children, ...props }) => {
   const slideToPrev = () => {
     if (disabled) return;
 
-    const newIndex = currentIndex - slidesToScroll;
+    const newIndex =
+      currentIndex - slidesToScroll > limitIndex
+        ? currentIndex - slidesToScroll
+        : limitIndex;
 
     throttle(() => setCurrentIndex(newIndex, dispatch), speed);
   };
@@ -197,7 +202,10 @@ const SliderNextButton = ({ children, ...props }) => {
   const slideToNext = () => {
     if (disabled) return;
 
-    const newIndex = currentIndex + slidesToScroll;
+    const newIndex =
+      currentIndex + slidesToScroll < limitIndex
+        ? currentIndex + slidesToScroll
+        : limitIndex;
 
     throttle(() => setCurrentIndex(newIndex, dispatch), speed);
   };

--- a/src/components/common/Slider/index.tsx
+++ b/src/components/common/Slider/index.tsx
@@ -12,12 +12,14 @@ type SliderOptions = {
   slidesToShow: number;
   slidesToScroll: number;
   slidesMargin: string;
+  arrows: boolean;
 };
 
 const defaultSliderOptions = {
   slidesToShow: 1,
   slidesToScroll: 1,
   slidesMargin: '0px',
+  arrows: true,
 };
 
 type SliderProps = {
@@ -154,7 +156,7 @@ const setCurrentIndex = (
 
 const SliderPrevButton = ({ children, ...props }) => {
   const [{ options, currentIndex }, dispatch] = useSliderContext();
-  const { slidesToScroll } = options;
+  const { slidesToScroll, arrows } = options;
   const limitIndex = 0;
   const disabled = currentIndex <= limitIndex;
 
@@ -170,7 +172,7 @@ const SliderPrevButton = ({ children, ...props }) => {
     slideToPrev();
   };
 
-  return (
+  return arrows ? (
     <button
       type="button"
       onClick={handlePrevButtonClick}
@@ -179,12 +181,12 @@ const SliderPrevButton = ({ children, ...props }) => {
     >
       {children}
     </button>
-  );
+  ) : null;
 };
 
 const SliderNextButton = ({ children, ...props }) => {
   const [{ options, currentIndex, slideLength }, dispatch] = useSliderContext();
-  const { slidesToShow, slidesToScroll } = options;
+  const { slidesToShow, slidesToScroll, arrows } = options;
   const limitIndex = slideLength - slidesToShow;
   const disabled = currentIndex >= limitIndex;
 
@@ -200,7 +202,7 @@ const SliderNextButton = ({ children, ...props }) => {
     slideToNext();
   };
 
-  return (
+  return arrows ? (
     <button
       type="button"
       onClick={handleNextButtonClick}
@@ -209,7 +211,7 @@ const SliderNextButton = ({ children, ...props }) => {
     >
       {children}
     </button>
-  );
+  ) : null;
 };
 
 Slider.List = SliderList;

--- a/src/components/common/Slider/index.tsx
+++ b/src/components/common/Slider/index.tsx
@@ -210,7 +210,6 @@ const SliderPrevButton = ({ children, ...restProps }) => {
 
   const handlePrevButtonClick = () => {
     if (disabled) return;
-    console.log(currentIndex);
 
     const decreasedIndex =
       currentIndex - slidesToScroll > limitIndex

--- a/src/utils/eventDelay.ts
+++ b/src/utils/eventDelay.ts
@@ -1,0 +1,15 @@
+const throttle = (() => {
+  let waiting = false;
+
+  return (callback: () => void, limit = 100) => {
+    if (waiting) return;
+
+    callback();
+    waiting = true;
+    setTimeout(() => {
+      waiting = false;
+    }, limit);
+  };
+})();
+
+export default throttle;

--- a/src/utils/eventDelay.ts
+++ b/src/utils/eventDelay.ts
@@ -1,15 +1,15 @@
-const throttle = (() => {
+const throttle = (callback: (args) => void, limit = 100) => {
   let waiting = false;
 
-  return (callback: () => void, limit = 100) => {
+  return (...args) => {
     if (waiting) return;
 
-    callback();
+    callback(args);
     waiting = true;
     setTimeout(() => {
       waiting = false;
     }, limit);
   };
-})();
+};
 
 export default throttle;


### PR DESCRIPTION
close #17

고민하며 리팩토링 때 수정을 많이 했더니 늦어졌네요 ^_ㅠ
파일이 길어 헷갈릴까봐 예시 코드를 적다보니 내용이 길어졌어요..!
<br>

# ☑️ 사용 예시
## 코드

```ts
const data = ['slide_0', 'slide_1', 'slide_2', ..., 'slide_10'];

const HomePage = () => (
  <PageLayout>
    <Slider
      options={{
        slidesToShow: 5,
        slidesToScroll: 3,
        slidesMargin: '10px',
        speed: 500,
      }}
    >
      <Slider.List>
        {data.map(item => (
          <Slider.Item  key={item}>{item}</Slider.Item>
        ))}
      </Slider.List>
      <div>
        <Slider.PrevButton>Prev</Slider.PrevButton>
        <Slider.NextButton>Next</Slider.NextButton>
      </div>
    </Slider>
  </PageLayout>
);
```
## 데모

https://user-images.githubusercontent.com/17706346/192958138-44197744-6509-43d1-a222-2f41b2a41707.mov

<br>

# ☑️ 고민한 부분
## slider item 개수 받아오기
데이터가 외부에 있고 해당 데이터를 통해 slider.item들을 생성하기 때문에 슬라이드 개수(slidesLength)는 SliderList에서 받아와야 합니다. 그런데 SliderList와 형제관계인 button에서도 슬라이드 개수가 필요합니다. 때문에 처음에는 SliderList 가 useEffect와 dispatch를 통해 개수를 업데이트 하도록했는데요.
```ts
const reducer = (state: SliderContextValues, action: SliderAction) => {
  const { type, payload } = action;

  switch (type) {
    case 'UPDATE_CURRENT_INDEX':
      return { ...state, currentIndex: payload.currentIndex };
    case 'SET_SLIDES_LENGTH':
      return { ...state, slideLength: payload.slideLength };
    default:
      return state;
  }
};

...

const SliderList = ({ children, ...props }) => {
  const [{ options }, dispatch] = useSliderContext();

  useEffect(() => {
    dispatch({
      type: 'SET_SLIDES_LENGTH',
      payload: { slideLength: children.length },
    });
  }, [dispatch, children.length]);
```
이렇게 되면 개수를 받아오기 위해 재렌더하는게 비효율적이라고 느껴졌어요. 그래서 Slider가 children을 탐색하여 sliderList를 찾고 해당 리스트의 자식을 개수로 받아오는 로직으로 구현했습니다. List 하위에는 item 외에 들어올 일이 없다고 판단되어 변경했습니다.
```ts
const getSlidesLength = () => {
    const sliderList = Children.toArray(children).find((child: ReactNode) => {
      if (
        child?.type.name === 'SliderList' ||
        child?.type.target.name === 'SliderList'
      )
        return true;
      return false;
    });
    const slidesLength = sliderList ? sliderList.props.children.length : 0;
```

## context 분리
현재 Slider가 하위 자식들과 공유해야하는 상태는 options, slidesLength, currentIndex 3가지 인데요. 이 중에서 값이 바뀌는건 currentIndex밖에 없습니다. 때문에 처음에 3가지를 하나의 context에 넘기다가 분리를 했습니다. 파크가 햄디 PR에  [children에 prop](https://github.com/Co-Studo/Co-Studo-front/pull/24#discussion_r980998816)으로 넘기는 방식을 말하셔서 저도 변경되는 값이 아닌것들은 cloneElement를 통해 children에 넘겨주려고 했는데요. 저같은 경우는 children의 depth가 1depth가 아니여서 고민하다  아래와 같이 재귀로 구현을 했는데요..!
```ts
const givePropsToChildren = (childrenWithoutProps) => {
    const childrenWithProps = Children.map(childrenWithoutProps, (child) => {
      if (!child.props) return child;

      const lowerChildren = givePropsToChildren(child.props.children);
      return cloneElement(child, {
        ...child.props,
        options: sliderOptions,
        slidesLength: getSlidesLength(),
        children: lowerChildren,
      });
    });
```
이렇게 하면 모든 children에게 잘 전달됐습니다. 근데 외부에서 넘겨준 스타일이 적용이 안되더라구요. head
less에서 적용한 스타일은 잘 적용됐지만 headless를 사용하는 곳에서 전달한 css는 적용이 devTool로 children을 확인해보니 에 저렇게 적용한 스타일이 들어있더라구요.
<img width="507" alt="스크린샷 2022-09-30 오전 3 30 20" src="https://user-images.githubusercontent.com/17706346/193114042-9dc3ac04-8b44-49a1-9b25-7f45eabed343.png">

근데 화면에 계속 적용안된 모습이 나오는 ^_ㅠ  
그러다 context를 분리했을 때 provider를 분리하면 해당 context를 사용하는 children만 재렌더되는 걸 스터디 때 들은 기억이 났습니다.([제이미 발표](https://jamie-log.notion.site/Hook-7-30b13fa016c4495fb0451ebde6703f42)) 재귀 로직을 사용하여 props drilling으로 전달하는거보다 context를 분리하는게 나을거 같아 해당 방법으로 바꿔 적용했습니다.
```ts
const SliderProvider = ({ ..., children}: SliderProviderProps) => {
  ...
  return (
    <SliderInfoContext.Provider value={sliderInfo}>
      <SliderItemIndexContext.Provider value={sliderItemIndexReducer}>
        {children}
      </SliderItemIndexContext.Provider>
    </SliderInfoContext.Provider>
  );
};

const Slider = ({ options = defaultSliderOptions, children }: SliderProps) => {
  ...
  return (
    <SliderProvider options={sliderOptions} slidesLength={getSlidesLength()}>
      { ... }
    </SliderProvider>
```

<br>

# ☑️ 의견이 궁금한 부분
## onClick 이벤트 핸들러를 prop으로 받아야 하나?
햄디가 radio 컴포넌트에서 상태를 외부에서 주입 받은거처럼 slider 라이브러리를 공부하다 [muterial-ui-carousel](https://github.com/Learus/react-material-ui-carousel) 이라는 리액트 라이브러리가 있더라구요.
근데 해당 라이브러리는 옵션이 많이 없었어요. 화면에 하나의 슬라이드만 보이고 하나씩만 넘어가는 기본 슬라이드인데 자기가 한 슬라이드에 여러 슬라이드를 넣고 몇개씩 넘길건지 계산하여 onClick prop으로 넘겨주는 방식이더라구요.([예시](https://codesandbox.io/s/xcl6o?file=/src/Card.jsx:2126-2133))
처음에는 라이브러리의 기능이 너무 적다라고 생각했는데 외부에 상태를 두고 원하는대로 주입하는게 좀 더 리액트스럽지 않나?라는 생각도 들더라구요.
그런데 또 라이브러리가 이런 로직을 계산 안하려고 쓰는거 아닌가?라는 생각도 들어서 일단은 구현했으니 그냥 두었습니다.
혹시 이 부분에 대해서는 어떻게 생각하시나요?