### PR TITLE
[Jamie][RE] Row, Tab Component 생성 

### DIFF
--- a/src/components/common/Row/index.tsx
+++ b/src/components/common/Row/index.tsx
@@ -9,15 +9,20 @@ type RowProps = {
   right?: ReactElement;
 };
 
-const Row = ({ title, description, left, right }: RowProps) => (
-  <S.Container>
-    <S.Box>{left}</S.Box>
-    <S.Main>
-      <S.Box>{title}</S.Box>
-      <S.Box>{description}</S.Box>
-    </S.Main>
-    <S.Box>{right}</S.Box>
-  </S.Container>
-);
+const Row = ({ title, description, left, right }: RowProps) => {
+  const isString = (prop) => prop && typeof prop === 'string';
+  const wrapString = (prop) => isString(prop) && <S.Box>{prop}</S.Box>; // TODO: Text 컴포넌트로 교체
+
+  return (
+    <S.Container>
+      {left}
+      <S.Main>
+        {isString(title) ? wrapString(title) : title}
+        {isString(description) ? wrapString(description) : description}
+      </S.Main>
+      {right}
+    </S.Container>
+  );
+};
 
 export default Row;

--- a/src/components/common/Row/index.tsx
+++ b/src/components/common/Row/index.tsx
@@ -1,12 +1,12 @@
-import { ReactNode } from 'react';
+import { ReactElement } from 'react';
 
 import * as S from '@components/common/Row/row.styled';
 
 type RowProps = {
-  title: ReactNode;
-  description: ReactNode;
-  left: ReactNode;
-  right: ReactNode;
+  title: ReactElement | string;
+  description?: ReactElement | string;
+  left?: ReactElement;
+  right?: ReactElement;
 };
 
 const Row = ({ title, description, left, right }: RowProps) => (

--- a/src/components/common/Row/row.stories.tsx
+++ b/src/components/common/Row/row.stories.tsx
@@ -8,11 +8,11 @@ export default {
   args: {
     title: '제목',
     description: '설명',
-    left: 'o',
-    right: 'x',
+    left: <div>left</div>,
+    right: <div>right</div>
   },
 } as ComponentMeta<typeof Row>;
 
 export const Default: ComponentStory<typeof Row> = (args) => (
-  <Row {...args} />
+  <Row {...args}  />
 );

--- a/src/components/common/Tab/index.tsx
+++ b/src/components/common/Tab/index.tsx
@@ -10,10 +10,10 @@ import {
   ReactElement,
 } from 'react';
 
-type TabState = {
-  activeIndex: number;
-  activateTab: Dispatch<SetStateAction<number>>;
-};
+type TabState = [
+  activeIndex: number,
+  setActiveIndex: Dispatch<SetStateAction<number>>,
+];
 
 const TabContext = createContext<TabState | null>(null);
 TabContext.displayName = 'TabContext';
@@ -32,12 +32,10 @@ type TabGroupProps = {
 };
 
 const TabGroup = ({ defaultIndex, children, ...restProps }: TabGroupProps) => {
-  const [activeIndex, activateTab] = useState(defaultIndex || 0);
-
-  const value = { activeIndex, activateTab };
+  const activeIndexState = useState(defaultIndex || 0);
 
   return (
-    <TabContext.Provider value={value}>
+    <TabContext.Provider value={activeIndexState}>
       <div {...restProps}>{children}</div>
     </TabContext.Provider>
   );
@@ -63,10 +61,10 @@ type TabPropsType = {
 };
 
 const Tab = ({ tabId, children, ...restProps }: TabPropsType) => {
-  const { activeIndex, activateTab } = useTabContext();
-
+  const [activeIndex, setActiveIndex] = useTabContext();
   const isActive = activeIndex === tabId;
-  const handleTabClick = () => tabId !== undefined && activateTab(tabId);
+
+  const handleTabClick = () => tabId !== undefined && setActiveIndex(tabId);
 
   return (
     <li {...restProps} data-selected={isActive}>
@@ -97,8 +95,7 @@ type TabPanelProps = {
 };
 
 const TabPanel = ({ tabId, children, ...restProps }: TabPanelProps) => {
-  const { activeIndex } = useTabContext();
-
+  const [activeIndex] = useTabContext();
   const isActive = activeIndex === tabId;
 
   return isActive ? <div {...restProps}>{children}</div> : null;

--- a/src/components/common/Tab/tab.a.styled.tsx
+++ b/src/components/common/Tab/tab.a.styled.tsx
@@ -7,7 +7,7 @@ const StyledTabList = styled(Tab.List)`
   gap: 20px;
 `;
 
-const StyledTabRoot = styled(Tab)`
+const StyledTab = styled(Tab)`
   cursor: pointer;
   
   * {
@@ -26,11 +26,9 @@ const StyledTabPanel = styled(Tab.Panel)`
   color: #939393;
 `;
 
-const StyledTab = Object.assign(StyledTabRoot, {
-  Group: Tab.Group,
-  List: StyledTabList,
-  Panels: Tab.Panels,
-  Panel: StyledTabPanel,
-})
+StyledTab.Group = Tab.Group;
+StyledTab.List = StyledTabList;
+StyledTab.Panels = Tab.Panels;
+StyledTab.Panel = StyledTabPanel;
 
 export default StyledTab;


### PR DESCRIPTION
close #20 

실수로 지난 PR이 머지되어서 새로 열었어요!
추가로 리뷰 다실 분이 있다면 달아주시고, 수정사항이 생기면 여기서 반영하도록 하겠습니다.

## 수정된 사항

- TabContext에 State 넘겨주는 방식
  파크가 의견 주신대로 네이밍과 사용되지 않는 것들을 굳이 디스트럭처링할 필요가 없을 것 같아 수정하였습니다.
- 스타일 파일에서의 `Object.assign()` 사용
  깜빡하고 수정하지 못했던 부분이라 반영하였습니다. 다만 `tab.b.styled.tsx` 파일에서는 `ActiveBar`가 추가되면서 기존 방식대로 하면 타입 에러가 발생해서 그대로 `Object.assign()` 방식을 사용했습니다.
- Row 컴포넌트 props의 타입 변경
  기존의 `ReactNode` 타입의 경우 컴포넌트 외에 `number`, `boolean` 등의 값이 들어올 여지가 있어 `ReactElement` 타입으로 변경하였고, title과 description의 경우 `string`도 추가로 받을 수 있도록 설정해주었습니다. (left, right는 텍스트만 들어올 경우가 없을 것이라고 판단)
- `string` 타입의 props를 container로 감싸도록 함
`string` 타입의 값이 들어올 경우 레이아웃이 깨질 수 있으므로 `string` 타입인지 체크한 후 래핑해주도록 처리했습니다.