### PR TITLE
[Hemdi] TextField 컴포넌트

### DIFF
--- a/src/components/common/TextField/index.tsx
+++ b/src/components/common/TextField/index.tsx
@@ -1,0 +1,160 @@
+import {
+  Children,
+  cloneElement,
+  createContext,
+  Dispatch,
+  forwardRef,
+  InputHTMLAttributes,
+  ReactElement,
+  ReactNode,
+  SetStateAction,
+  useContext,
+  useState,
+  useEffect,
+} from 'react';
+
+import useInputValidation, {
+  Validity,
+} from '@components/common/TextField/useTextValidation';
+
+const initState: Validity = {
+  isPass: false,
+  isError: false,
+};
+
+type TextFieldState = [
+  validity: Validity,
+  setValidity: Dispatch<SetStateAction<Validity>>,
+];
+
+const TextFieldContext = createContext<TextFieldState | null>(null);
+TextFieldContext.displayName = 'TextFieldContext';
+
+const useTextFieldContext = () => {
+  const context = useContext(TextFieldContext);
+  if (!context) {
+    throw new Error(
+      'useTextFieldContext should be used within TextFieldContext.Provider',
+    );
+  }
+  return context;
+};
+
+export interface TextFieldProps {
+  id?: string;
+  name: string;
+  children: ReactElement | ReactElement[];
+}
+
+const TextField = ({ id, name, children, ...restProps }: TextFieldProps) => {
+  const inputId = id ?? `input-${name}`;
+  const validityState = useState(initState);
+
+  return (
+    <TextFieldContext.Provider value={validityState}>
+      <div {...restProps}>
+        {Children.map(children, (child) =>
+          cloneElement(child, { id: inputId, name }),
+        )}
+      </div>
+    </TextFieldContext.Provider>
+  );
+};
+
+type TextInputType =
+  | 'text'
+  | 'email'
+  | 'number'
+  | 'password'
+  | 'search'
+  | 'tel'
+  | 'url';
+
+export interface InputProps extends InputHTMLAttributes<HTMLInputElement> {
+  type?: TextInputType;
+  onValidate?: (result: Validity) => void;
+  validate?: (value: string) => boolean;
+}
+
+const Input = forwardRef<HTMLInputElement, InputProps>(
+  (
+    {
+      validate,
+      onValidate,
+      type,
+      id,
+      name,
+      required,
+      onChange,
+      onBlur,
+      ...restProps
+    },
+    ref,
+  ) => {
+    const [{ isPass, isError }, setValidity] = useTextFieldContext();
+    const { validity, eventWrapper } = useInputValidation({
+      validate,
+      onValidate,
+    });
+
+    useEffect(() => {
+      setValidity(validity);
+    }, [validity, setValidity]);
+
+    return (
+      <input
+        type={type}
+        id={id}
+        ref={ref}
+        data-error={isError}
+        data-passed={isPass}
+        aria-invalid={!isPass}
+        aria-required={required}
+        aria-labelledby={id}
+        aria-describedby={`${id}-helper`}
+        onChange={(e) => eventWrapper(e, onChange)}
+        onBlur={(e) => eventWrapper(e, onBlur)}
+        {...restProps}
+      />
+    );
+  },
+);
+
+type TextFieldChildProps = {
+  id?: string;
+  children: ReactNode;
+};
+
+const Label = ({ id, children, ...restProps }: TextFieldChildProps) => {
+  const [{ isPass, isError }] = useTextFieldContext();
+  return (
+    <label
+      htmlFor={id}
+      data-error={isError}
+      data-passed={isPass}
+      {...restProps}
+    >
+      {children}
+    </label>
+  );
+};
+
+const HelperText = ({ id, children, ...restProps }: TextFieldChildProps) => {
+  const [{ isPass, isError }] = useTextFieldContext();
+  return (
+    <div
+      id={`${id}-helper`}
+      data-error={isError}
+      data-passed={isPass}
+      {...restProps}
+    >
+      {children}
+    </div>
+  );
+};
+
+TextField.Input = Input;
+TextField.Label = Label;
+TextField.HelperText = HelperText;
+
+export default TextField;

--- a/src/components/common/TextField/textField.stories.tsx
+++ b/src/components/common/TextField/textField.stories.tsx
@@ -1,0 +1,44 @@
+import { ComponentStory, ComponentMeta } from '@storybook/react';
+import { useState } from 'react';
+
+import TextField from '@components/common/TextField';
+import StyledTextField from '@components/common/TextField/textField.styled';
+import { Validity } from '@components/common/TextField/useTextValidation';
+
+export default {
+  title: 'common/TextField',
+  component: TextField,
+} as ComponentMeta<typeof TextField>;
+
+export const Default: ComponentStory<typeof TextField> = () => {
+  const [errorMsg, setErrorMsg] = useState('');
+
+  const handleOnBlur = (e) => {
+    console.log('blur :', e.target.value);
+  };
+
+  const handleValidation = ({ isError, isPass }: Validity) => {
+    if (isError) {
+      setErrorMsg('5 ~ 8 자 이내로 입력해주세요!');
+    }
+    if (isPass) {
+      setErrorMsg('');
+    }
+  };
+
+  const checkMaxLength = (value: string) => value?.length <= 8;
+
+  return (
+    <StyledTextField name="study">
+      <StyledTextField.Label>스터디 이름</StyledTextField.Label>
+      <StyledTextField.Input
+        type="text"
+        onBlur={handleOnBlur}
+        validate={checkMaxLength}
+        onValidate={handleValidation}
+        minLength={5}
+      />
+      <StyledTextField.HelperText>{errorMsg}</StyledTextField.HelperText>
+    </StyledTextField>
+  );
+};

--- a/src/components/common/TextField/textField.styled.tsx
+++ b/src/components/common/TextField/textField.styled.tsx
@@ -1,0 +1,45 @@
+import styled from 'styled-components';
+
+import TextField from '@components/common/TextField';
+
+const StyledTextFieldRoot = styled(TextField)`
+  display: flex;
+  flex-direction: column;
+  width: 580px;
+  gap: 12px;
+`;
+
+const StyledInput = styled(TextField.Input)`
+  width: 580px;
+  height: 50px;
+  border: 1px solid ${({ theme }) => theme.palette.borderLine};
+  border-radius: 10px;
+  padding: 0 10px;
+  font-size: 1rem;
+  :focus {
+    border-color: ${({ theme }) => theme.palette.primary};
+  }
+
+  &[data-error='true'] {
+    border-color: ${({ theme }) => theme.palette.warning};
+  }
+`;
+
+const StyledLabel = styled(TextField.Label)`
+  font-size: 1rem;
+  font-weight: bold;
+  color: ${({ theme }) => theme.palette.primary};
+`;
+
+const StyledHelperText = styled(TextField.HelperText)`
+  font-size: 0.8rem;
+  color: ${({ theme }) => theme.palette.warning};
+`;
+
+const StyledTextField = Object.assign(StyledTextFieldRoot, {
+  Input: StyledInput,
+  Label: StyledLabel,
+  HelperText: StyledHelperText,
+});
+
+export default StyledTextField;

--- a/src/components/common/TextField/useTextValidation.tsx
+++ b/src/components/common/TextField/useTextValidation.tsx
@@ -1,0 +1,42 @@
+import { ChangeEvent, FocusEvent, useEffect, useState } from 'react';
+
+type InputEvent = ChangeEvent<HTMLInputElement> | FocusEvent<HTMLInputElement>;
+
+export type Validity = {
+  isPass?: boolean;
+  isError?: boolean;
+};
+
+type ValidationParams = {
+  onValidate?: (result: Validity) => void;
+  validate?: (value: string) => boolean;
+};
+
+const useInputValidation = ({ validate, onValidate }: ValidationParams) => {
+  const [validity, setValidity] = useState({ isPass: false, isError: false });
+
+  const validateTarget = (target) => {
+    if (!target.validity.valid || (validate && !validate(target.value))) {
+      setValidity({ isError: true, isPass: false });
+    } else setValidity({ isError: false, isPass: true });
+  };
+
+  const eventWrapper = <T extends InputEvent>(event: T, handleEvent) => {
+    if (!handleEvent) {
+      return;
+    }
+
+    validateTarget(event.target);
+    handleEvent(event);
+  };
+
+  useEffect(() => {
+    if (onValidate && typeof onValidate === 'function') {
+      onValidate(validity);
+    }
+  }, [validity, onValidate]);
+
+  return { validity, eventWrapper };
+};
+
+export default useInputValidation;


### PR DESCRIPTION
close #36

<details>
<summary><h2>1. 설계 / 요구사항<h2></summary>

### 1. 기능
- 기본적으로 제어 컴포넌트의 형식을 따른다.
- 한 줄로 사용자의 입력을 받을 수 있다.
- 입력의 타입은 키보드로 타이핑하여 입력 할 수 있는, Text 의 범주에 있는 input의 type들을 지원한다.
   - email, number, password, search, tel, text, url
- onChange, onBlur 등의 이벤트를 통하여 원하는 검증 로직을 수행 할 수 있도록 지원한다.
- 외부에서 내부의 input 컴포넌트의 직접적인 헨들링을 위한 방법으로 ref를 제공해준다.
    - ex : focus 등의 처리
- 내부의 상태로 검증 결과인 isError, isPass 상태를 가진다.
  
### 2. 형태
- input의 title 역할을 하는 Label과 도움 글 또는 오류 메세지를 표시하기 위한 HelperText 컴포넌트를 제공한다.
- Label과 HelperText 에는 문자열 뿐 아니라 컴포넌트를 넣을 수 있도록 제공한다.
- 검증 결과에 따라 input을 커스텀 할 수 있는 방법을 제공한다.
    - data-attribute : data-pass, data-error
    - input 가상 클래스 : valid, invalid

```ts
&[data-error='true'] {
    border-color: ${({ theme }) => theme.palette.warning};
  }
```

### 3. 접근성
- **Input**
    - input 의 속성으로 required 를 사용한 경우 aria-required 속성을 true로 지정해준다.
    - input 에 입력된 값이 유효한지 아닌지에 대한 결과를 aria-invalid=true로 지정해준다.
- **Label**
    - 명시적으로 연결짓기 위해 동일한 id를 부여해준다.
        - ex : input.id === label.htmlFor
    - input에 aria-labelledby 또는 aria-label 속성으로 label의 id를 지정해준다.
- **HelperText**
    - HelperText 의 id를 input 의 aria-describedby 속성의 값으로 지정하여 추가 설명이라는 걸 표시한다.

</details>

## 2. 사용 예시
```tsx
<TextField name="study">
      <TextField.Label>스터디 이름</TextField.Label>
      <TextField.Input
        type="text"
        onBlur={handleOnBlur}
        validate={checkMaxLength}
        onValidate={handleValidation}
        minLength={5}
      />
      <TextField.HelperText>{errorMsg}</TextField.HelperText>
</TextField>
```
  
## 2. 주요 고민 사항

### ✨ Validation
TextField 컴포넌트에서 자체적으로 validation 기능을 제공해주고 싶어 구현을 해봤습니다.
TextField.Input의 props로 원하는 검증 함수(validation)을 넘기고 onBlur 등과 같은 이벤트에 핸들러 함수를 추가하면
해당 이벤트가 실행 될 때 관련 hook을 통해 검증 함수를 실행합니다.
이때 검증 결과는 onValidate 라는 prop에 넘긴 함수로 받을 수 있습니다.

하지만 구현하고 보니 과정도 복잡하고 빠진 기능들이 있어서 개선이 좀 필요한 것 같습니다.
특히 현재 핸들러를 추가한 모든 이벤트에서 검증 로직을 수행하는데 이 부분을 원하는 이벤트에만 검증 할 수 있게 하거나,
현재는 단순히 true, false로 결과를 받는데 케이스에 따라 조금 더 결과를 처리 할 수 있게 하면 좋을 것 같습니다.
debounce 도 추가하면 좋을 것 같구요...!

그리고 또 검증 기능을 hook으로 분리하여 구현했더니 TextField에 종속적이지 않고 다른 컴포넌트에서 재사용하여 사용 할 수 있게 구현하는게 좋을 것 같다는 생각이 듭니다...@_@)...

### ✨ Label, HelperText
이전 RadioGroup을 처음 구현 했을 때 추가했었던 Title 컴포넌트와 비슷하게 필수로 제공해줘야 하는 기능인지,
다른 Input 컴포넌트들과 겹치는 요소라 중복으로 구현하는 것은 아닌지에 대한 고민이 들어 넣었다 뺐다를 많이 했습니다....
결국 다른 Input 컴포넌트들 과의 중복과 Form 을 구현할 때 추가해야 하는 요소인가 싶어 제거를 했었는데
[디자인 시스템, 형태를 넘어서](https://youtu.be/ajtpcFkXqqg?t=3118) 영상에서 사용자가 고려하지 않도록 접근성을 지원해주면 좋다고하여 접근성을 지원한다는 목적으로 다시 추가 해봤습니다.

### ✨ text 타입들
처음부터 TextField 컴포넌트를 의식하고 구현해서 type을 text 범주의 타입들로 한정 짓고 컴포넌트를 구현했습니다.
하지만 구현하고 보니 검증 기능, Label, HelperText 기능들이 단순히 TextField 컴포넌트에만 필요한 기능이 아니라 Input 컴포넌트 자체에서 type과 상관없이 가지고 있어도 괜찮을 기능 같기도 해서 type 제한을 제거 하고 Input으로 만드는게 나을지 고민이 됐습니다.

---

아직 깔끔하게 마무리 짓고 올리는 것이 아니라 개선이 필요한 부분이 🔥정말 많이🔥 있는 것 같습니다!
개선과 관련한 피드백 열렬히 환영합니다...!! ㅠ_ㅠ)/