### PR TITLE
[Park] FlexBox Component

### DIFF
--- a/src/components/common/Box/index.tsx
+++ b/src/components/common/Box/index.tsx
@@ -1,3 +1,5 @@
+import styled from 'styled-components';
+
 type BoxSX = {
   justifyContent?:
     | 'flex-start'
@@ -8,22 +10,27 @@ type BoxSX = {
     | 'space-evenly';
   alignItems?: 'center' | 'flex-start' | 'flex-end';
   flexDirection?: 'row' | 'column';
+  gap?: string;
 };
 
 type BoxProps = {
+  as?: React.ElementType;
   children: React.ReactNode;
   sx?: BoxSX;
 };
 
+const Wrapper = styled.div`
+  display: flex;
+`;
+
 const Box = (props: BoxProps) => {
-  const { sx, children } = props;
+  const { sx, as = 'div', children } = props;
 
-  const boxCss = {
-    display: 'flex',
-    ...sx,
-  };
-
-  return <div css={boxCss}>{children}</div>;
+  return (
+    <Wrapper as={as} css={sx}>
+      {children}
+    </Wrapper>
+  );
 };
 
 export default Box;

--- a/src/components/common/Box/index.tsx
+++ b/src/components/common/Box/index.tsx
@@ -1,0 +1,29 @@
+type BoxSX = {
+  justifyContent?:
+    | 'flex-start'
+    | 'flex-end'
+    | 'center'
+    | 'space-between'
+    | 'space-around'
+    | 'space-evenly';
+  alignItems?: 'center' | 'flex-start' | 'flex-end';
+  flexDirection?: 'row' | 'column';
+};
+
+type BoxProps = {
+  children: React.ReactNode;
+  sx?: BoxSX;
+};
+
+const Box = (props: BoxProps) => {
+  const { sx, children } = props;
+
+  const boxCss = {
+    display: 'flex',
+    ...sx,
+  };
+
+  return <div css={boxCss}>{children}</div>;
+};
+
+export default Box;

--- a/src/components/common/FlexBox/flexBox.stories.tsx
+++ b/src/components/common/FlexBox/flexBox.stories.tsx
@@ -1,0 +1,24 @@
+import { ComponentStory, ComponentMeta } from '@storybook/react';
+
+import Paper from '@components/common/Paper';
+
+import FlexBox from '.';
+
+export default {
+  title: 'common/FlexBox',
+  component: FlexBox,
+  args: {
+    children: (
+      <>
+        <div>플랙스</div>
+        <div>박스</div>
+      </>
+    ),
+  },
+} as ComponentMeta<typeof FlexBox>;
+
+export const Default: ComponentStory<typeof FlexBox> = (args) => (
+  <Paper>
+    <FlexBox {...args} />
+  </Paper>
+);

--- a/src/components/common/FlexBox/index.tsx
+++ b/src/components/common/FlexBox/index.tsx
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 
-type BoxSX = {
+type FlexBoxSX = {
   justifyContent?:
     | 'flex-start'
     | 'flex-end'
@@ -13,17 +13,17 @@ type BoxSX = {
   gap?: string;
 };
 
-type BoxProps = {
+type FlexBoxProps = {
   as?: React.ElementType;
   children: React.ReactNode;
-  sx?: BoxSX;
+  sx?: FlexBoxSX;
 };
 
 const Wrapper = styled.div`
   display: flex;
 `;
 
-const Box = (props: BoxProps) => {
+const FlexBox = (props: FlexBoxProps) => {
   const { sx, as = 'div', children } = props;
 
   return (
@@ -33,4 +33,4 @@ const Box = (props: BoxProps) => {
   );
 };
 
-export default Box;
+export default FlexBox;


### PR DESCRIPTION
close #67 

Box 라는 네이밍으로 지으려다가, `display:flex` 가 기본 동작임을 명시하기 위해 FlexBox 라는 이름으로 변경해 보았습니다.

도니도 겪으신 문제일 것 같은데 처음에는 as 를 아래처럼 사용하려 했습니다. ([reference](https://kciter.so/posts/polymorphic-react-component))

```tsx
const FlexBox = (props: FlexBoxProps) => {
  const { sx, as, children } = props;
  const Component = as || 'div';
  return <Component css={sx}>{children}</Component>;
};
```

css prop 을 사용하지 않을 때에는 오류가 나지 않는데, css prop 을 사용하는 순간부터는 Component 를 찾을 수 없다는 오류메세지를 보게됩니다. 

<img width="516" alt="스크린샷 2022-10-26 오후 2 55 38" src="https://user-images.githubusercontent.com/58503584/197946303-1e0ea837-bdee-44ae-b8e2-bfbdae640b67.png">

아마 babel-plugin-styled-components 쪽 문제라고 생각이 드는데, 저희 프로젝트가 주로 css prop 을 사용하는 방향으로 정했기에 
styled-components 에서 @emotion 으로 넘어가는 것도 의논해보는게 어떤지 여쭤보고 싶습니다. 
( emotion이 SSR 에 더 safety 하다는 말도 있는데, playground 를 Next 로 사용하면 또 어떤 문제가 있을 수도 있음 )

그래서 Styled-components 에서 as 를 사용하는 법을 제공하는 방식대로 일단은 처리했습니다.

```tsx
const Wrapper = styled.div`
  display: flex;
`;

const FlexBox = (props: FlexBoxProps) => {
  const { sx, as = 'div', children } = props;

  return (
    <Wrapper as={as} css={sx}>
      {children}
    </Wrapper>
  );
};
```

### TODO

gap 은 일단 string 으로 제한했지만, 이것도 디자인을 기반으로 설정된 값으로 타입을 지정하고 제한하는게 맞다고 생각이 듭니다.
