### PR TITLE
[Dony] Table 컴포넌트 구현

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -53,6 +53,7 @@ module.exports = {
     'react/react-in-jsx-scope': 'off',
     'react/require-default-props': 'off',
     'react/jsx-no-constructed-context-values': 'off',
+    'react/no-array-index-key': 'off',
     'import/order': [
       'error',
       {

--- a/src/components/common/Table/index.tsx
+++ b/src/components/common/Table/index.tsx
@@ -1,9 +1,8 @@
-/* eslint-disable react/no-array-index-key */
-import { ReactNode, ReactElement, Children } from 'react';
-import { css, useTheme } from 'styled-components';
+import { ReactNode, ReactElement, ComponentProps } from 'react';
+import { css } from 'styled-components';
 
-import Text, { TextSX } from '@components/common/Text';
-import { IPalette } from '@styles/theme';
+import FlexBox from '@components/common/FlexBox';
+import Text from '@components/common/Text';
 
 type TableDefaultProps = {
   children: ReactElement | ReactElement[];
@@ -21,6 +20,7 @@ const Table = ({ caption, cellWidth, children }: TableProps) => (
       width: 100%;
       overflow: hidden;
       border-top: ${({ theme }) => `0.1rem solid ${theme.palette.borderLine}`};
+      table-layout: fixed;
     `}
   >
     <caption
@@ -60,49 +60,27 @@ const Tbody = ({ children }: TableDefaultProps) => (
   </tbody>
 );
 
-type TrSX = {
-  background?: keyof IPalette;
-};
-
-export interface TrProps extends TableDefaultProps {
-  sx?: TrSX;
-}
-
-const Tr = ({ sx, children }: TrProps) => {
-  const theme = useTheme();
-
-  return (
-    <tr
-      css={{
-        borderBottom: `0.1rem solid ${theme.palette.borderLine}`,
-        ...sx,
-      }}
-    >
-      {children}
-    </tr>
-  );
-};
+const Tr = ({ children }: TableDefaultProps) => (
+  <tr
+    css={css`
+      border-bottom: ${({ theme }) =>
+        `0.1rem solid ${theme.palette.borderLine}`};
+    `}
+  >
+    {children}
+  </tr>
+);
 
 type CellSX = {
   width?: string;
   justifyContent?: 'center' | 'flex-start';
-  textOverflow?: 'ellipsis' | 'clip';
-  whiteSpace?: 'nowrap' | 'normal';
 };
 
-const defaultCellSX: TextSX = {
-  textAlign: 'center',
-  textOverflow: 'ellipsis',
-  whiteSpace: 'nowrap',
-};
-
-const cellCss = {
-  display: 'flex',
+const flexCss = {
+  justifyContent: 'center',
   alignItems: 'center',
   gap: '10px',
-  padding: '1.7rem 2rem',
-  overflow: 'hidden',
-};
+} as Pick<ComponentProps<typeof FlexBox>, 'sx'>;
 
 type ThProps = {
   colSpan?: number;
@@ -110,19 +88,11 @@ type ThProps = {
   children: ReactNode;
 };
 
-const Th = ({ sx, children, ...restProps }: ThProps) => (
-  <th {...restProps}>
-    <div css={{ ...cellCss, justifyContent: 'center', ...sx }}>
-      {Children.map(children, (child) =>
-        typeof child === 'string' ? (
-          <Text.Highlight as="b" sx={{ ...defaultCellSX, fontWeight: 'bold' }}>
-            {child}
-          </Text.Highlight>
-        ) : (
-          child
-        ),
-      )}
-    </div>
+const Th = ({ sx = {}, children, ...restProps }: ThProps) => (
+  <th css={{ padding: '1.7rem 2rem' }} {...restProps}>
+    <Text as="div" sx={{ fontWeight: 'bold' }}>
+      <FlexBox sx={{ ...flexCss, ...sx }}>{children}</FlexBox>
+    </Text>
   </th>
 );
 
@@ -130,19 +100,9 @@ export interface TdProps extends ThProps {
   rowSpan?: number;
 }
 
-const Td = ({ sx, children, ...restProps }: TdProps) => (
-  <td {...restProps}>
-    <div css={{ ...cellCss, ...sx }}>
-      {Children.map(children, (child) =>
-        typeof child === 'string' ? (
-          <Text as="span" sx={defaultCellSX}>
-            {child}
-          </Text>
-        ) : (
-          child
-        ),
-      )}
-    </div>
+const Td = ({ sx = {}, children, ...restProps }: TdProps) => (
+  <td css={{ padding: '1.7rem 2rem' }} {...restProps}>
+    <FlexBox sx={{ ...flexCss, ...sx }}>{children}</FlexBox>
   </td>
 );
 

--- a/src/components/common/Table/index.tsx
+++ b/src/components/common/Table/index.tsx
@@ -89,7 +89,7 @@ type ThProps = {
 };
 
 const Th = ({ sx = {}, children, ...restProps }: ThProps) => (
-  <th css={{ padding: '1.7rem 2rem' }} {...restProps}>
+  <th scope="col" css={{ padding: '1.7rem 2rem' }} {...restProps}>
     <Text as="div" sx={{ fontWeight: 'bold' }}>
       <FlexBox sx={{ ...flexCss, ...sx }}>{children}</FlexBox>
     </Text>

--- a/src/components/common/Table/index.tsx
+++ b/src/components/common/Table/index.tsx
@@ -3,6 +3,7 @@ import { css } from 'styled-components';
 
 import FlexBox from '@components/common/FlexBox';
 import Text from '@components/common/Text';
+import { offscreen } from '@styles/commonStyles';
 
 type TableDefaultProps = {
   children: ReactElement | ReactElement[];
@@ -10,11 +11,10 @@ type TableDefaultProps = {
 
 export interface TableProps extends TableDefaultProps {
   caption: string;
-  cellWidth?: string[];
-  children: ReactElement | ReactElement[];
+  columnsWidth?: string[];
 }
 
-const Table = ({ caption, cellWidth, children }: TableProps) => (
+const Table = ({ caption, columnsWidth, children }: TableProps) => (
   <table
     css={css`
       width: 100%;
@@ -23,21 +23,10 @@ const Table = ({ caption, cellWidth, children }: TableProps) => (
       table-layout: fixed;
     `}
   >
-    <caption
-      css={css`
-        position: absolute;
-        width: 1px;
-        height: 1px;
-        margin: -1px;
-        overflow: hidden;
-        clip-path: polygon(0 0, 0 0, 0 0);
-      `}
-    >
-      {caption}
-    </caption>
-    {cellWidth && (
+    <caption css={offscreen}>{caption}</caption>
+    {columnsWidth && (
       <colgroup>
-        {cellWidth?.map((width, index) => (
+        {columnsWidth.map((width, index) => (
           <col key={index} width={width} />
         ))}
       </colgroup>
@@ -79,7 +68,7 @@ type CellSX = {
 const flexCss = {
   justifyContent: 'center',
   alignItems: 'center',
-  gap: '10px',
+  gap: '1rem',
 } as Pick<ComponentProps<typeof FlexBox>, 'sx'>;
 
 type ThProps = {
@@ -106,10 +95,10 @@ const Td = ({ sx = {}, children, ...restProps }: TdProps) => (
   </td>
 );
 
-Table.Thead = Thead;
-Table.Tbody = Tbody;
-Table.Tr = Tr;
-Table.Th = Th;
-Table.Td = Td;
+Table.Head = Thead;
+Table.Body = Tbody;
+Table.Row = Tr;
+Table.HeadCell = Th;
+Table.BodyCell = Td;
 
 export default Table;

--- a/src/components/common/Table/index.tsx
+++ b/src/components/common/Table/index.tsx
@@ -1,0 +1,155 @@
+/* eslint-disable react/no-array-index-key */
+import { ReactNode, ReactElement, Children } from 'react';
+import { css, useTheme } from 'styled-components';
+
+import Text, { TextSX } from '@components/common/Text';
+import { IPalette } from '@styles/theme';
+
+type TableDefaultProps = {
+  children: ReactElement | ReactElement[];
+};
+
+export interface TableProps extends TableDefaultProps {
+  caption: string;
+  cellWidth?: string[];
+  children: ReactElement | ReactElement[];
+}
+
+const Table = ({ caption, cellWidth, children }: TableProps) => (
+  <table
+    css={css`
+      width: 100%;
+      overflow: hidden;
+      border-top: ${({ theme }) => `0.1rem solid ${theme.palette.borderLine}`};
+    `}
+  >
+    <caption
+      css={css`
+        position: absolute;
+        width: 1px;
+        height: 1px;
+        margin: -1px;
+        overflow: hidden;
+        clip-path: polygon(0 0, 0 0, 0 0);
+      `}
+    >
+      {caption}
+    </caption>
+    {cellWidth && (
+      <colgroup>
+        {cellWidth?.map((width, index) => (
+          <col key={index} width={width} />
+        ))}
+      </colgroup>
+    )}
+    {children}
+  </table>
+);
+
+const Thead = ({ children }: TableDefaultProps) => <thead>{children}</thead>;
+
+const Tbody = ({ children }: TableDefaultProps) => (
+  <tbody
+    css={css`
+      tr:hover {
+        background: ${({ theme }) => theme.palette.hoverColor};
+      }
+    `}
+  >
+    {children}
+  </tbody>
+);
+
+type TrSX = {
+  background?: keyof IPalette;
+};
+
+export interface TrProps extends TableDefaultProps {
+  sx?: TrSX;
+}
+
+const Tr = ({ sx, children }: TrProps) => {
+  const theme = useTheme();
+
+  return (
+    <tr
+      css={{
+        borderBottom: `0.1rem solid ${theme.palette.borderLine}`,
+        ...sx,
+      }}
+    >
+      {children}
+    </tr>
+  );
+};
+
+type CellSX = {
+  width?: string;
+  justifyContent?: 'center' | 'flex-start';
+  textOverflow?: 'ellipsis' | 'clip';
+  whiteSpace?: 'nowrap' | 'normal';
+};
+
+const defaultCellSX: TextSX = {
+  textAlign: 'center',
+  textOverflow: 'ellipsis',
+  whiteSpace: 'nowrap',
+};
+
+const cellCss = {
+  display: 'flex',
+  alignItems: 'center',
+  gap: '10px',
+  padding: '1.7rem 2rem',
+  overflow: 'hidden',
+};
+
+type ThProps = {
+  colSpan?: number;
+  sx?: CellSX;
+  children: ReactNode;
+};
+
+const Th = ({ sx, children, ...restProps }: ThProps) => (
+  <th {...restProps}>
+    <div css={{ ...cellCss, justifyContent: 'center', ...sx }}>
+      {Children.map(children, (child) =>
+        typeof child === 'string' ? (
+          <Text.Highlight as="b" sx={{ ...defaultCellSX, fontWeight: 'bold' }}>
+            {child}
+          </Text.Highlight>
+        ) : (
+          child
+        ),
+      )}
+    </div>
+  </th>
+);
+
+export interface TdProps extends ThProps {
+  rowSpan?: number;
+}
+
+const Td = ({ sx, children, ...restProps }: TdProps) => (
+  <td {...restProps}>
+    <div css={{ ...cellCss, ...sx }}>
+      {Children.map(children, (child) =>
+        typeof child === 'string' ? (
+          <Text as="span" sx={defaultCellSX}>
+            {child}
+          </Text>
+        ) : (
+          child
+        ),
+      )}
+    </div>
+  </td>
+);
+
+Table.Thead = Thead;
+Table.Tbody = Tbody;
+Table.Tr = Tr;
+Table.Th = Th;
+Table.Td = Td;
+
+export default Table;

--- a/src/components/common/Table/table.stories.tsx
+++ b/src/components/common/Table/table.stories.tsx
@@ -1,0 +1,61 @@
+import { ComponentStory, ComponentMeta } from '@storybook/react';
+
+import Table from '@components/common/Table';
+
+export default {
+  title: 'common/Table',
+  component: Table,
+} as ComponentMeta<typeof Table>;
+
+const noticeList = [
+  {
+    id: 1,
+    title: '스터디 가입전 해당 공지사항을 숙지해주세요.',
+    writer: '파크',
+    date: '2022.10.22',
+    view: 101,
+    isFixed: true,
+    isNew: false,
+  },
+  {
+    id: 2,
+    title: '스터디 전체 공지 드립니다.',
+    writer: '파크크크크',
+    date: '1시간 전',
+    view: 11,
+    isFixed: true,
+    isNew: true,
+  },
+];
+
+export const Default: ComponentStory<typeof Table> = () => (
+  <Table caption="공지사항" cellWidth={['85px', '*', '120px', '120px', '85px']}>
+    <Table.Thead>
+      <Table.Tr>
+        <Table.Th>번호</Table.Th>
+        <Table.Th>제목</Table.Th>
+        <Table.Th>작성자</Table.Th>
+        <Table.Th>날짜</Table.Th>
+        <Table.Th>조회수</Table.Th>
+      </Table.Tr>
+    </Table.Thead>
+    <Table.Tbody>
+      {noticeList.reverse().map(({ id, title, writer, date, view }) => (
+        <Table.Tr key={id}>
+          <Table.Td>{id}</Table.Td>
+          <Table.Td>{title}</Table.Td>
+          <Table.Td>
+            {writer}
+            <img
+              src="https://cdn-icons-png.flaticon.com/512/32/32213.png"
+              alt="arrow"
+              css={{ height: '20px' }}
+            />
+          </Table.Td>
+          <Table.Td>{date}</Table.Td>
+          <Table.Td>{view}</Table.Td>
+        </Table.Tr>
+      ))}
+    </Table.Tbody>
+  </Table>
+);

--- a/src/components/common/Table/table.stories.tsx
+++ b/src/components/common/Table/table.stories.tsx
@@ -1,6 +1,8 @@
 import { ComponentStory, ComponentMeta } from '@storybook/react';
 
+import Icon from '@components/common/Icon';
 import Table from '@components/common/Table';
+import Text from '@components/common/Text';
 
 export default {
   title: 'common/Table',
@@ -16,19 +18,21 @@ const noticeList = [
     view: 101,
     isFixed: true,
     isNew: false,
+    commentCount: 14,
   },
   {
     id: 2,
     title: '스터디 전체 공지 드립니다.',
-    writer: '파크크크크',
+    writer: '파크크크크크크크크',
     date: '1시간 전',
     view: 11,
     isFixed: true,
     isNew: true,
+    commentCount: 0,
   },
 ];
 
-export const Default: ComponentStory<typeof Table> = () => (
+export const NoticeList: ComponentStory<typeof Table> = () => (
   <Table caption="공지사항" cellWidth={['85px', '*', '120px', '120px', '85px']}>
     <Table.Thead>
       <Table.Tr>
@@ -40,20 +44,149 @@ export const Default: ComponentStory<typeof Table> = () => (
       </Table.Tr>
     </Table.Thead>
     <Table.Tbody>
-      {noticeList.reverse().map(({ id, title, writer, date, view }) => (
-        <Table.Tr key={id}>
-          <Table.Td>{id}</Table.Td>
-          <Table.Td>{title}</Table.Td>
-          <Table.Td>
-            {writer}
-            <img
-              src="https://cdn-icons-png.flaticon.com/512/32/32213.png"
-              alt="arrow"
-              css={{ height: '20px' }}
-            />
+      {noticeList
+        .reverse()
+        .map(({ id, title, writer, date, view, commentCount }) => (
+          <Table.Tr key={id}>
+            <Table.Td>
+              <Text ellipsis>{id}</Text>
+            </Table.Td>
+            <Table.Td
+              sx={{
+                justifyContent: 'flex-start',
+              }}
+            >
+              <Text ellipsis>{title}</Text>
+              {commentCount > 0 && (
+                <Text.Highlight
+                  as="b"
+                  sx={{ fontWeight: 'bold', color: 'primary' }}
+                >
+                  {commentCount}
+                </Text.Highlight>
+              )}
+            </Table.Td>
+            <Table.Td>
+              <Text ellipsis>{writer}</Text>
+            </Table.Td>
+            <Table.Td>
+              <Text ellipsis>{date}</Text>
+            </Table.Td>
+            <Table.Td>
+              <Text ellipsis>{view}</Text>
+            </Table.Td>
+          </Table.Tr>
+        ))}
+    </Table.Tbody>
+  </Table>
+);
+
+const memberManagementList = [
+  {
+    id: 1,
+    nickName: 'Hemdi',
+    status: 'waiting',
+    dateOfSubscription: '2022.10.22',
+    periodOfActivity: 0,
+    uncheckin: 0,
+    uncheckout: 0,
+    penaltyPoint: 0,
+  },
+  {
+    id: 2,
+    nickName: 'Jamie',
+    status: 'warning',
+    dateOfSubscription: '2022.10.22',
+    periodOfActivity: 0,
+    uncheckin: 0,
+    uncheckout: 10,
+    penaltyPoint: 990,
+  },
+  {
+    id: 3,
+    nickName: 'Park',
+    status: 'member',
+    dateOfSubscription: '2022.10.22',
+    periodOfActivity: 0,
+    uncheckin: 0,
+    uncheckout: 0,
+    penaltyPoint: 0,
+  },
+];
+
+const STATUS = {
+  member: {
+    text: '활동 중',
+    color: 'primary',
+  },
+  waiting: {
+    text: '가입 승인 대기 중',
+    color: 'fontColor',
+  },
+  warning: {
+    text: '벌점 초과',
+    color: 'warning',
+  },
+  danger: {
+    text: '경고 대상',
+    color: 'danger',
+  },
+};
+
+export const MemberManagementList: ComponentStory<typeof Table> = () => (
+  <Table
+    caption="스터디 멤버 관리"
+    cellWidth={['*', '15%', '15%', '13%', '13%', '13%', '13%']}
+  >
+    <Table.Thead>
+      <Table.Tr>
+        <Table.Th>닉네임</Table.Th>
+        <Table.Th>상태</Table.Th>
+        <Table.Th>가입일</Table.Th>
+        <Table.Th>활동일</Table.Th>
+        <Table.Th>
+          미 체크인
+          <Icon iconName="star" size="large" />
+        </Table.Th>
+        <Table.Th>
+          미 체크아웃
+          <Icon iconName="star" size="large" />
+        </Table.Th>
+        <Table.Th>벌점</Table.Th>
+      </Table.Tr>
+    </Table.Thead>
+    <Table.Tbody>
+      {memberManagementList.map((props) => (
+        <Table.Tr key={props.id}>
+          <Table.Td sx={{ justifyContent: 'flex-start' }}>
+            <Icon iconName="anonymous" size="large" color="borderLine" />
+            <Text ellipsis>{props.nickName}</Text>
           </Table.Td>
-          <Table.Td>{date}</Table.Td>
-          <Table.Td>{view}</Table.Td>
+          <Table.Td>
+            <Text ellipsis>
+              <Text.Highlight
+                as="strong"
+                sx={{ fontWeight: 'bold', color: STATUS[props.status].color }}
+              >
+                {STATUS[props.status].text}
+              </Text.Highlight>
+            </Text>
+          </Table.Td>
+          <Table.Td>
+            <Text ellipsis>{props.dateOfSubscription}</Text>
+          </Table.Td>
+          <Table.Td>
+            <Text ellipsis>{props.periodOfActivity}일</Text>
+          </Table.Td>
+          <Table.Td>
+            <Text ellipsis>{props.uncheckin}회</Text>
+          </Table.Td>
+          <Table.Td>
+            <Text ellipsis>{props.uncheckout}회</Text>
+          </Table.Td>
+          <Table.Td>
+            <Text ellipsis>{props.penaltyPoint}점</Text>
+          </Table.Td>
         </Table.Tr>
       ))}
     </Table.Tbody>

--- a/src/components/common/Table/table.stories.tsx
+++ b/src/components/common/Table/table.stories.tsx
@@ -33,25 +33,28 @@ const noticeList = [
 ];
 
 export const NoticeList: ComponentStory<typeof Table> = () => (
-  <Table caption="공지사항" cellWidth={['85px', '*', '120px', '120px', '85px']}>
-    <Table.Thead>
-      <Table.Tr>
-        <Table.Th>번호</Table.Th>
-        <Table.Th>제목</Table.Th>
-        <Table.Th>작성자</Table.Th>
-        <Table.Th>날짜</Table.Th>
-        <Table.Th>조회수</Table.Th>
-      </Table.Tr>
-    </Table.Thead>
-    <Table.Tbody>
+  <Table
+    caption="공지사항"
+    columnsWidth={['85px', '*', '120px', '120px', '85px']}
+  >
+    <Table.Head>
+      <Table.Row>
+        <Table.HeadCell>번호</Table.HeadCell>
+        <Table.HeadCell>제목</Table.HeadCell>
+        <Table.HeadCell>작성자</Table.HeadCell>
+        <Table.HeadCell>날짜</Table.HeadCell>
+        <Table.HeadCell>조회수</Table.HeadCell>
+      </Table.Row>
+    </Table.Head>
+    <Table.Body>
       {noticeList
         .reverse()
         .map(({ id, title, writer, date, view, commentCount }) => (
-          <Table.Tr key={id}>
-            <Table.Td>
+          <Table.Row key={id}>
+            <Table.BodyCell>
               <Text ellipsis>{id}</Text>
-            </Table.Td>
-            <Table.Td
+            </Table.BodyCell>
+            <Table.BodyCell
               sx={{
                 justifyContent: 'flex-start',
               }}
@@ -65,19 +68,19 @@ export const NoticeList: ComponentStory<typeof Table> = () => (
                   {commentCount}
                 </Text.Highlight>
               )}
-            </Table.Td>
-            <Table.Td>
+            </Table.BodyCell>
+            <Table.BodyCell>
               <Text ellipsis>{writer}</Text>
-            </Table.Td>
-            <Table.Td>
+            </Table.BodyCell>
+            <Table.BodyCell>
               <Text ellipsis>{date}</Text>
-            </Table.Td>
-            <Table.Td>
+            </Table.BodyCell>
+            <Table.BodyCell>
               <Text ellipsis>{view}</Text>
-            </Table.Td>
-          </Table.Tr>
+            </Table.BodyCell>
+          </Table.Row>
         ))}
-    </Table.Tbody>
+    </Table.Body>
   </Table>
 );
 
@@ -136,33 +139,33 @@ const STATUS = {
 export const MemberManagementList: ComponentStory<typeof Table> = () => (
   <Table
     caption="스터디 멤버 관리"
-    cellWidth={['*', '15%', '15%', '13%', '13%', '13%', '13%']}
+    columnsWidth={['*', '15%', '15%', '13%', '13%', '13%', '13%']}
   >
-    <Table.Thead>
-      <Table.Tr>
-        <Table.Th>닉네임</Table.Th>
-        <Table.Th>상태</Table.Th>
-        <Table.Th>가입일</Table.Th>
-        <Table.Th>활동일</Table.Th>
-        <Table.Th>
+    <Table.Head>
+      <Table.Row>
+        <Table.HeadCell>닉네임</Table.HeadCell>
+        <Table.HeadCell>상태</Table.HeadCell>
+        <Table.HeadCell>가입일</Table.HeadCell>
+        <Table.HeadCell>활동일</Table.HeadCell>
+        <Table.HeadCell>
           미 체크인
           <Icon iconName="star" size="large" />
-        </Table.Th>
-        <Table.Th>
+        </Table.HeadCell>
+        <Table.HeadCell>
           미 체크아웃
           <Icon iconName="star" size="large" />
-        </Table.Th>
-        <Table.Th>벌점</Table.Th>
-      </Table.Tr>
-    </Table.Thead>
-    <Table.Tbody>
+        </Table.HeadCell>
+        <Table.HeadCell>벌점</Table.HeadCell>
+      </Table.Row>
+    </Table.Head>
+    <Table.Body>
       {memberManagementList.map((props) => (
-        <Table.Tr key={props.id}>
-          <Table.Td sx={{ justifyContent: 'flex-start' }}>
+        <Table.Row key={props.id}>
+          <Table.BodyCell sx={{ justifyContent: 'flex-start' }}>
             <Icon iconName="anonymous" size="large" color="borderLine" />
             <Text ellipsis>{props.nickName}</Text>
-          </Table.Td>
-          <Table.Td>
+          </Table.BodyCell>
+          <Table.BodyCell>
             <Text ellipsis>
               <Text.Highlight
                 as="strong"
@@ -171,24 +174,24 @@ export const MemberManagementList: ComponentStory<typeof Table> = () => (
                 {STATUS[props.status].text}
               </Text.Highlight>
             </Text>
-          </Table.Td>
-          <Table.Td>
+          </Table.BodyCell>
+          <Table.BodyCell>
             <Text ellipsis>{props.dateOfSubscription}</Text>
-          </Table.Td>
-          <Table.Td>
+          </Table.BodyCell>
+          <Table.BodyCell>
             <Text ellipsis>{props.periodOfActivity}일</Text>
-          </Table.Td>
-          <Table.Td>
+          </Table.BodyCell>
+          <Table.BodyCell>
             <Text ellipsis>{props.uncheckin}회</Text>
-          </Table.Td>
-          <Table.Td>
+          </Table.BodyCell>
+          <Table.BodyCell>
             <Text ellipsis>{props.uncheckout}회</Text>
-          </Table.Td>
-          <Table.Td>
+          </Table.BodyCell>
+          <Table.BodyCell>
             <Text ellipsis>{props.penaltyPoint}점</Text>
-          </Table.Td>
-        </Table.Tr>
+          </Table.BodyCell>
+        </Table.Row>
       ))}
-    </Table.Tbody>
+    </Table.Body>
   </Table>
 );

--- a/src/styles/commonStyles.ts
+++ b/src/styles/commonStyles.ts
@@ -1,0 +1,10 @@
+import { CSSObject } from 'styled-components';
+
+export const offscreen: CSSObject = {
+  position: 'absolute',
+  width: '1px',
+  height: '1px',
+  margin: '-1px',
+  overflow: 'hidden',
+  clipPath: 'polygon(0 0, 0 0, 0 0)',
+};


### PR DESCRIPTION
close #65 

<br>

## 설계
### 기능 / 형태
- table -> thead, tbody -> tr -> th, td 순으로 children을 사용한다.
- th, td에 chlidren을 넣어주면 flex 되어 10px 간격으로 가로로 배치된다.
- table에 cellWidth를 배열로 지정해주면 colgroup으로 th, td 넓이가 지정된다.
  - 배열에 `*` 사용 시 나머지 크기를 해당 index의 cell(th, td)이 차지한다.
- th, td는 항상 한 줄이며 지정된 넓이를 넘을 시 ... 처리된다. (텍스트만)
- tbody에 있는 tr에 hover시, background-color가 변한다.

### 접근성
- caption을 사용하여 table이 어떤 표를 나타내는지 명시
- th에 scope를 지정하여 제목행이 가로인지 세로인지 명시

<br>

## 고민한 사항
### th, td의 width
> table에 cellWidth를 배열로 지정해주면 colgroup으로 th, td 넓이가 지정된다.

th, td의 넓이를 지정해주기 위해서는 css를 통해 cell에 직접 넓이를 지정해주거나 html 태그인 colgroup으로 지정해주는 2가지 방법이 있습니다. cell에 직접 지정해줄 경우 th, td 마다 모두 넓이를 지정해줘야하고, colgroup 처럼 * 기능이 없어 유동적으로 늘어나는 cell의 넓이는 calc로 계산해서 지정해줘야하는 불편함이 있어 colgroup으로 지정해주는 방식을 사용했습니다.

### ellipsis 처리
> th, td는 항상 한 줄이며 지정된 넓이를 넘을 시 ... 처리된다. (텍스트만)

해당 부분을 처리하기 위해 Text 컴포넌트를 td 안에 넣었었지만
1. FlexBox 안에 Text를 넣을 경우 
```tsx
<td>
  <FlexBox sx={{ ...flexCss, ...sx }}>
    <Text as="div" ellipsis>{children}</Text>
  </FlexBox>
</td>
```
이 경우, children으로 text와 icon이 들어오는 경우 가로로 배치되지 못합니다.
display: flex는 바로 하위 자식들만 배치하기 때문입니다.

2. Text 안에 FlexBox를 넣을 경우
```tsx
<td>
  <Text as="div" ellipsis>
    <FlexBox sx={{ ...flexCss, ...sx }}>{children}</FlexBox>
  </Text>
</td>
```
이 경우, ... 처리가 되지 않습니다.
때문에 외부에서 ... 처리를 하고 싶은 cell의 경우, 또 폰트를 변경하고 싶은 cell의 경우에 Text를 이용하여 children으로 넣어주는 방식이 낫다고 판단했습니다.

