### PR TITLE
[Dony] iconSizes iconName에 따라 분리

### DIFF
--- a/src/components/common/Icon/index.tsx
+++ b/src/components/common/Icon/index.tsx
@@ -5,21 +5,36 @@ import { Palette } from '@styles/theme';
 
 type IconProps = {
   iconName: IconName;
-  size?: 'small' | 'medium' | 'large';
+  size?: 'small' | 'medium' | 'large' | 'xLarge';
   color?: keyof Palette;
 };
 
 const iconSizes = {
-  small: '0.5rem',
-  medium: '1rem',
-  large: '2rem',
+  anonymous: {
+    small: '3.2rem',
+    medium: '4.2rem',
+    large: '5rem',
+    xLarge: '14.2rem',
+  },
+  bell: {
+    medium: '3.2rem',
+  },
+  crown: {
+    medium: '2.1rem',
+  },
+  lock: {
+    medium: '1.3rem',
+  },
+  star: {
+    medium: '2.5rem',
+  },
 };
 
-const Icon = ({ iconName, size = 'small', color }: IconProps) => {
+const Icon = ({ iconName, size = 'medium', color }: IconProps) => {
   const IconComponent = icon[iconName];
 
   const StyledIcon = styled(IconComponent)`
-    width: ${iconSizes[size]};
+    width: ${iconSizes[iconName][size] || iconSizes[iconName].medium};
     height: auto;
     fill: ${({ theme }) => theme.palette[color || 'primary']};
     stroke: ${({ theme }) => theme.palette[color || 'primary']};


### PR DESCRIPTION
close #82 

<br>

## 개선한 내용
현재 모든 아이콘이 한 사이즈 표에 따라가다 보니 실제 사이즈와 다른 부분이 많고, 한 표로 통일하기엔 아이콘이 세로로 긴 아이콘, 가로가 긴 아이콘, 가로 세로가 같은 형태가 있어 하나의 width 표로 통일하기 힘들다는 생각이 듭니다.
때문에 iconName에 따라 사이즈가 달라지도록 개선해봤습니다.
