### PR TITLE
[Hemdi] FlexBoxSX 사이즈, 간격 관련 속성 추가

### DIFF
--- a/src/components/common/FlexBox/index.tsx
+++ b/src/components/common/FlexBox/index.tsx
@@ -1,6 +1,15 @@
 import styled from 'styled-components';
 
-type FlexBoxSX = {
+interface SizeSX {
+  width?: string;
+  maxWidth?: string;
+  minWidth?: string;
+  height?: string;
+  maxHeight?: string;
+  minHeight?: string;
+}
+
+export interface FlexBoxSX extends SizeSX {
   justifyContent?:
     | 'flex-start'
     | 'flex-end'
@@ -10,8 +19,7 @@ type FlexBoxSX = {
     | 'space-evenly';
   alignItems?: 'center' | 'flex-start' | 'flex-end';
   flexDirection?: 'row' | 'column';
-  gap?: string;
-};
+}
 
 type FlexBoxProps = {
   as?: React.ElementType;

--- a/src/components/common/FlexBox/index.tsx
+++ b/src/components/common/FlexBox/index.tsx
@@ -6,16 +6,20 @@ import {
   getSpacingCssProps,
 } from '@components/common/FlexBox/spacing';
 
-interface SizeSX {
+type SizeSX = {
   width?: string;
   maxWidth?: string;
   minWidth?: string;
   height?: string;
   maxHeight?: string;
   minHeight?: string;
-}
+};
 
-export interface FlexBoxSX extends SpacingSX, SizeSX {
+type StyleSX = {
+  background?: string;
+};
+
+export interface FlexBoxSX extends SizeSX, SpacingSX, StyleSX {
   justifyContent?:
     | 'flex-start'
     | 'flex-end'

--- a/src/components/common/FlexBox/index.tsx
+++ b/src/components/common/FlexBox/index.tsx
@@ -4,6 +4,7 @@ import {
   SpacingSX,
   isSpacingProp,
   getSpacingCssProps,
+  SpacingValue,
 } from '@components/common/FlexBox/spacing';
 import colors from '@styles/colors';
 import { Palette } from '@styles/theme';
@@ -31,6 +32,7 @@ export interface FlexBoxSX extends SizeSX, SpacingSX, StyleSX {
     | 'space-evenly';
   alignItems?: 'center' | 'flex-start' | 'flex-end';
   flexDirection?: 'row' | 'column';
+  gap?: SpacingValue;
 }
 
 type FlexBoxProps = {

--- a/src/components/common/FlexBox/index.tsx
+++ b/src/components/common/FlexBox/index.tsx
@@ -1,5 +1,11 @@
 import styled from 'styled-components';
 
+import {
+  SpacingSX,
+  isSpacingProp,
+  getSpacingCssProps,
+} from '@components/common/FlexBox/spacing';
+
 interface SizeSX {
   width?: string;
   maxWidth?: string;
@@ -9,7 +15,7 @@ interface SizeSX {
   minHeight?: string;
 }
 
-export interface FlexBoxSX extends SizeSX {
+export interface FlexBoxSX extends SpacingSX, SizeSX {
   justifyContent?:
     | 'flex-start'
     | 'flex-end'
@@ -31,11 +37,20 @@ const Wrapper = styled.div`
   display: flex;
 `;
 
+const getFlexCssProperties = (sx: FlexBoxSX) =>
+  Object.keys(sx).reduce(
+    (css, key) =>
+      isSpacingProp(key)
+        ? { ...css, ...getSpacingCssProps(key, sx[key]) }
+        : { ...css, [key]: sx[key] },
+    {},
+  );
+
 const FlexBox = (props: FlexBoxProps) => {
   const { sx, as = 'div', children } = props;
-
+  const css = sx && getFlexCssProperties(sx);
   return (
-    <Wrapper as={as} css={sx}>
+    <Wrapper as={as} css={css}>
       {children}
     </Wrapper>
   );

--- a/src/components/common/FlexBox/index.tsx
+++ b/src/components/common/FlexBox/index.tsx
@@ -1,10 +1,12 @@
-import styled from 'styled-components';
+import styled, { DefaultTheme, useTheme } from 'styled-components';
 
 import {
   SpacingSX,
   isSpacingProp,
   getSpacingCssProps,
 } from '@components/common/FlexBox/spacing';
+import colors from '@styles/colors';
+import { Palette } from '@styles/theme';
 
 type SizeSX = {
   width?: string;
@@ -16,7 +18,7 @@ type SizeSX = {
 };
 
 type StyleSX = {
-  background?: string;
+  bgColor?: keyof typeof colors | keyof Palette;
 };
 
 export interface FlexBoxSX extends SizeSX, SpacingSX, StyleSX {
@@ -41,18 +43,20 @@ const Wrapper = styled.div`
   display: flex;
 `;
 
-const getFlexCssProperties = (sx: FlexBoxSX) =>
-  Object.keys(sx).reduce(
-    (css, key) =>
-      isSpacingProp(key)
-        ? { ...css, ...getSpacingCssProps(key, sx[key]) }
-        : { ...css, [key]: sx[key] },
-    {},
-  );
+const getFlexCssProperties = (sx: FlexBoxSX, theme: DefaultTheme) =>
+  Object.entries(sx).reduce((css, [key, value]) => {
+    if (key === 'bgColor') {
+      return { ...css, backgroundColor: theme.palette[value] ?? colors[value] };
+    }
+    return isSpacingProp(key)
+      ? { ...css, ...getSpacingCssProps(key, value) }
+      : { ...css, [key]: value };
+  }, {});
 
 const FlexBox = (props: FlexBoxProps) => {
   const { sx, as = 'div', children } = props;
-  const css = sx && getFlexCssProperties(sx);
+  const theme = useTheme();
+  const css = sx && getFlexCssProperties(sx, theme);
   return (
     <Wrapper as={as} css={css}>
       {children}

--- a/src/components/common/FlexBox/spacing.tsx
+++ b/src/components/common/FlexBox/spacing.tsx
@@ -4,11 +4,8 @@ export type SpacingValue = typeof spacing[number] | string;
 
 export type Margin = Partial<Record<MarginKey, SpacingValue>>;
 export type Padding = Partial<Record<PaddingKey, SpacingValue>>;
-export type Gap = SpacingValue;
 
-export interface SpacingSX extends Margin, Padding {
-  gap?: Gap;
-}
+export interface SpacingSX extends Margin, Padding {}
 
 const spacing = [0.5, 1, 1.5, 2, 2.5] as const;
 const marginKeys = ['m', 'mt', 'mr', 'mb', 'ml', 'mx', 'my'] as const;

--- a/src/components/common/FlexBox/spacing.tsx
+++ b/src/components/common/FlexBox/spacing.tsx
@@ -1,0 +1,54 @@
+export type MarginKey = typeof marginKeys[number];
+export type PaddingKey = typeof paddingKeys[number];
+export type SpacingValue = typeof spacing[number] | string;
+
+export type Margin = Partial<Record<MarginKey, SpacingValue>>;
+export type Padding = Partial<Record<PaddingKey, SpacingValue>>;
+export type Gap = SpacingValue;
+
+export interface SpacingSX extends Margin, Padding {
+  gap?: Gap;
+}
+
+const spacing = [0.5, 1, 1.5, 2, 2.5] as const;
+const marginKeys = ['m', 'mt', 'mr', 'mb', 'ml', 'mx', 'my'] as const;
+const paddingKeys = ['p', 'pt', 'pr', 'pb', 'pl', 'px', 'py'] as const;
+
+const properties = {
+  m: 'margin',
+  p: 'padding',
+};
+
+const directions = {
+  t: 'Top',
+  r: 'Right',
+  b: 'Bottom',
+  l: 'Left',
+  x: ['Right', 'Left'],
+  y: ['Top', 'Bottom'],
+};
+
+export const isSpacingProp = (key) =>
+  marginKeys.includes(key) || paddingKeys.includes(key);
+
+export const getSpacingCssProps = (key: string, value: SpacingValue) => {
+  const [propKey, dirKey] = key.split('');
+  const property = properties[propKey];
+  const direction = directions?.[dirKey];
+
+  const spacingValue = typeof value === 'string' ? value : `${value}rem`;
+
+  if (Array.isArray(direction)) {
+    return direction.reduce(
+      (prev, dir) => ({
+        ...prev,
+        [property + dir]: spacingValue,
+      }),
+      {},
+    );
+  }
+
+  return {
+    [property + (direction || '')]: spacingValue,
+  };
+};

--- a/src/components/common/FlexBox/spacing.tsx
+++ b/src/components/common/FlexBox/spacing.tsx
@@ -32,6 +32,8 @@ export const isSpacingProp = (key) =>
   marginKeys.includes(key) || paddingKeys.includes(key);
 
 export const getSpacingCssProps = (key: string, value: SpacingValue) => {
+  if (typeof value !== 'string' && !spacing.includes(value)) return {};
+
   const [propKey, dirKey] = key.split('');
   const property = properties[propKey];
   const direction = directions?.[dirKey];


### PR DESCRIPTION
close #90

## ✨ 구현 내역
기존의 PageLayout 의 스타일을 개선하던 중에 아래와 같이 FlexBoxSX에 추가 속성이 필요하게 되어 작업했습니다.
```tsx
<FlexBox
  sx={{
    ...
    maxWidth: '1270px',
    height: '100%',
    padding: '6rem',
    background: colors.white,
  }}
>
  {children}
</FlexBox>
```

### 1. width, height 관련 속성 추가
```tsx
type SizeSX {
  width?: string;
  maxWidth?: string;
  minWidth?: string;
  height?: string;
  maxHeight?: string;
  minHeight?: string;
}
```
단순히 width, height 뿐 아니라 전체 레이아웃을 잡기 위해 max, min 값도 필요하게되어 SizeSX 라고 타입을 분리하여 전부 추가하였습니다.

### 2. background 속성 추가
```tsx
type StyleSX = {
  bgColor?: keyof typeof colors | keyof Palette;
};

// 적용 할 때
 Object.entries(sx).reduce((css, [key, value]) => {
    if (key === 'bgColor') {
      return { ...css, backgroundColor: theme.palette[value] ?? colors[value] };
    }
...
}
```
레이아웃을 잡은 FlexBox에 흰 배경색을 추가해야 해서 bgColor 라는 속성을 추가하였습니다.

> ⚠️ 이때 bgColor의 type을 저희 디자인 시스템의 기획 의도대로라면 typeof Palette 로만 한정 짓고 Palette에 네이밍 된 색을 가져와 사용하는게 맞는 방향 같은데 현재 **Palette에 PageLayout에서 필요한 white 색이 없어서** 우선은 colors 값을 사용할 수 있게 추가해놨습니다. 따라서 해당 부분은 이전 **11월 2주차 주간회의에서 Palette의 값들을 좀 더 세분화하기로 결정** 했던대로 Palette가 수정되면 colors 타입이 삭제 되는 등의 개선의 여지가 있습니다.

### 3. margin & padding 속성 추가
[mui-system/spacing](https://mui.com/system/spacing/) 을 참고하여 margin와 padding 속성을 추가했습니다.
<img width="594" alt="스크린샷 2022-11-16 오후 9 37 00" src="https://user-images.githubusercontent.com/34249911/202182469-d7cb6247-feaa-4122-a095-bcbafd2cacec.png">

```tsx
const spacing = [0.5, 1, 1.5, 2, 2.5] as const;
const marginKeys = ['m', 'mt', 'mr', 'mb', 'ml', 'mx', 'my'] as const;
const paddingKeys = ['p', 'pt', 'pr', 'pb', 'pl', 'px', 'py'] as const;

export type MarginKey = typeof marginKeys[number];
export type PaddingKey = typeof paddingKeys[number];
export type SpacingValue = typeof spacing[number] | string;

export type Margin = Partial<Record<MarginKey, SpacingValue>>;
export type Padding = Partial<Record<PaddingKey, SpacingValue>>;

export interface SpacingSX extends Margin, Padding {}
```

## 💭 고민 사항
### 1. spacing 배열값 사용법
<img width="857" alt="스크린샷 2022-11-16 오후 10 01 37" src="https://user-images.githubusercontent.com/34249911/202187415-47780519-4525-4fe6-b3b5-b4850780bc7f.png">

주간회의에서 함께 확인한대로 mui에서는 spacing의 값을 배열로 사용할 때 index 값을 이용해 사용했는데 index 값을 사용하면 **spacing 배열 중간에 값이 추가되거나 하는 등의 변경에 유연하게 대응하기 어려울 것** 같아 배열의 값들을 union 타입으로 만들어 지정하고 배열 내 값들을 직접 사용하는 식으로 구현했습니다.

<img width="821" alt="스크린샷 2022-11-16 오후 10 04 54" src="https://user-images.githubusercontent.com/34249911/202189051-eb143df7-11a2-4267-85b7-2c84094f0dc5.png">

혹시 더 나은 방식이 있을지, 변경에 대응하기 어려워도 다른 이유로 배열의 index 값을 사용하는게 나을지 의견 있으시다면 남겨주시면 감사하겠습니다!

### 2. spacing 파일의 위치
구현하고 보니 spacing.tsx 는 FlexBox와는 독립적으로 관리해도 괜찮은 모듈이 아닌가 싶은 생각이 들었습니다.
다른 컴포넌트들의 sx 속성에도 디자인 시스템의 규격에 맞추기위해 추가되어 쓰일 수 있을 것 같아서 만약 그렇게 되면 파일 위치를 어디에 두는게 좋을지 고민이 됩니다! @_@)
아예 공용으로 쓰일 수 있는 SX 속성들을 따로 모아두는 곳을 만들어두는 것도 괜찮을까 싶네요.