### PR TITLE
[Hemdi] RadioGroup useForm 적용

### DIFF
--- a/src/components/common/Form/Form.tsx
+++ b/src/components/common/Form/Form.tsx
@@ -23,11 +23,6 @@ FormContext.displayName = 'FormContext';
 
 export const useFormContext = () => {
   const context = useContext(FormContext);
-  if (!context) {
-    throw new Error(
-      'useFormContext should be used within FormContext.Provider',
-    );
-  }
   return context;
 };
 

--- a/src/components/common/Form/Form.tsx
+++ b/src/components/common/Form/Form.tsx
@@ -8,7 +8,7 @@ import {
   useState,
 } from 'react';
 
-type ValidationMode = 'onChange' | 'onBlur' | 'onSubmit';
+export type ValidationMode = 'onChange' | 'onBlur' | 'onSubmit';
 
 type FormContextType = {
   values: Record<string, string>;

--- a/src/components/common/Form/TextField.tsx
+++ b/src/components/common/Form/TextField.tsx
@@ -9,9 +9,10 @@ type InputTypes =
   | 'password'
   | 'search'
   | 'tel'
+  | 'date'
   | 'url';
 
-type TextFieldProps = {
+export type TextFieldProps = {
   validates?: (<V>(value: V) => boolean)[];
   defaultValue?: string;
   label?: ReactNode;
@@ -25,31 +26,38 @@ const TextField = ({
   defaultValue,
   label,
   name,
+  type,
   placeholder,
   ...restProps
 }: TextFieldProps) => {
-  const { subscribe, error } = useForm(name, defaultValue);
+  const { subscribe, error } = useForm(name, defaultValue) ?? {
+    subscribe: () => {},
+    error: null,
+  };
+
   const inputId = useId();
+  const isError = Boolean(error);
 
   return (
     <div {...restProps}>
       {label && (
-        <label htmlFor={inputId} data-error={Boolean(error)}>
+        <label htmlFor={inputId} data-error={isError}>
           {label}
         </label>
       )}
       <input
         name={name}
         id={inputId}
+        type={type}
         defaultValue={defaultValue}
         placeholder={placeholder}
-        data-error={Boolean(error)}
-        aria-invalid={Boolean(error)}
+        data-error={isError}
+        aria-invalid={isError}
         aria-labelledby={inputId}
         aria-describedby={`${inputId}-helper`}
         {...subscribe(validates)}
       />
-      {Boolean(error) && <span id={`${inputId}-helper`}>{error}</span>}
+      {isError && <span id={`${inputId}-helper`}>{error}</span>}
     </div>
   );
 };

--- a/src/components/common/Form/TextField.tsx
+++ b/src/components/common/Form/TextField.tsx
@@ -30,11 +30,7 @@ const TextField = ({
   placeholder,
   ...restProps
 }: TextFieldProps) => {
-  const { subscribe, error } = useForm(name, defaultValue) ?? {
-    subscribe: () => {},
-    error: null,
-  };
-
+  const { subscribe = () => {}, error } = useForm(name, defaultValue) ?? {};
   const inputId = useId();
   const isError = Boolean(error);
 

--- a/src/components/common/Form/form.styled.tsx
+++ b/src/components/common/Form/form.styled.tsx
@@ -51,8 +51,8 @@ const TextField = styled(Form.TextField)`
   }
 `;
 
-const StyledFrom = Object.assign(StyledFormRoot, {
+const StyledForm = Object.assign(StyledFormRoot, {
   TextField,
 });
 
-export default StyledFrom;
+export default StyledForm;

--- a/src/components/common/Form/useForm.tsx
+++ b/src/components/common/Form/useForm.tsx
@@ -1,6 +1,6 @@
 import { ChangeEvent, FocusEvent, useEffect } from 'react';
 
-import { useFormContext } from '@components/common/Form/Form';
+import { useFormContext, ValidationMode } from '@components/common/Form/Form';
 import { validate } from '@utils/validation';
 
 type InputEvent = ChangeEvent<HTMLInputElement> | FocusEvent<HTMLInputElement>;
@@ -13,6 +13,7 @@ export type FormHookReturns = {
   value: string;
   error: string;
   subscribe: Subscribe;
+  validationMode: ValidationMode;
 } | null;
 
 const useForm = (name: string, initValue?: string): FormHookReturns => {
@@ -58,7 +59,7 @@ const useForm = (name: string, initValue?: string): FormHookReturns => {
     return { [validationMode]: handleEvent };
   };
 
-  return { value, error, subscribe };
+  return { value, error, subscribe, validationMode };
 };
 
 export default useForm;

--- a/src/components/common/Form/useForm.tsx
+++ b/src/components/common/Form/useForm.tsx
@@ -13,16 +13,25 @@ export type FormHookReturns = {
   value: string;
   error: string;
   subscribe: Subscribe;
-};
+} | null;
 
 const useForm = (name: string, initValue?: string): FormHookReturns => {
+  const context = useFormContext();
+
+  useEffect(() => {
+    context?.setValues((prev) => ({ ...prev, [name]: initValue || '' }));
+    context?.setErrors((prev) => ({ ...prev, [name]: '' }));
+  }, []);
+
+  if (!context) return null;
+
   const {
     values,
     setValues,
     errors,
     setErrors,
     validationMode = 'onBlur',
-  } = useFormContext();
+  } = context;
 
   const value = values?.[name];
   const error = errors?.[name];
@@ -33,11 +42,6 @@ const useForm = (name: string, initValue?: string): FormHookReturns => {
   const setError = (newError: string) => {
     setErrors((prev) => ({ ...prev, [name]: newError }));
   };
-
-  useEffect(() => {
-    setValue(initValue || '');
-    setError('');
-  }, []);
 
   const subscribe: Subscribe = (validates) => {
     const handleEvent = (event: InputEvent) => {

--- a/src/components/common/RadioGroup/index.tsx
+++ b/src/components/common/RadioGroup/index.tsx
@@ -79,14 +79,15 @@ const Option = ({
   ...restProps
 }: OptionProps) => {
   const { selectedValue } = useRadioContext();
-  const formController = useForm(name, selectedValue);
+  const {
+    value: formValue,
+    subscribe = () => {},
+    validationMode = 'onChange',
+  } = useForm(name, selectedValue) ?? {};
 
   const optionId = id || `option-${name}-${value}`;
-  const isChecked = (formController?.value ?? selectedValue) === value;
-
-  const handleChange =
-    onChange ??
-    Object.values({ ...formController?.subscribe(validates) }).pop();
+  const isChecked = (formValue ?? selectedValue) === value;
+  const handleChange = onChange ?? subscribe(validates)[validationMode];
 
   return (
     <div {...restProps}>

--- a/src/components/common/RadioGroup/index.tsx
+++ b/src/components/common/RadioGroup/index.tsx
@@ -8,6 +8,8 @@ import {
   isValidElement,
 } from 'react';
 
+import useForm from '@components/common/Form/useForm';
+
 interface RadioState {
   selectedValue: string;
 }
@@ -36,11 +38,11 @@ const passPropsToChildren = <T,>(children: ReactNode, props: T) =>
 export interface RadioGroupProps extends RadioState {
   name: string;
   children: ReactNode;
-  onChange: (e: ChangeEvent<HTMLInputElement>) => void;
+  onChange?: (e: ChangeEvent<HTMLInputElement>) => void;
 }
 
 const RadioGroup = ({
-  selectedValue,
+  selectedValue = '',
   name,
   children,
   onChange,
@@ -48,6 +50,7 @@ const RadioGroup = ({
 }: RadioGroupProps) => {
   const state = { selectedValue };
   const childrenProps = { name, onChange };
+
   return (
     <RadioGroupContext.Provider value={state}>
       <div {...restProps}>{passPropsToChildren(children, childrenProps)}</div>
@@ -61,20 +64,30 @@ type OptionProps = {
   value: string;
   children: ReactNode;
   disabled?: boolean;
+  validates?: (<V>(value: V) => boolean)[];
   onChange?: (e: ChangeEvent<HTMLInputElement>) => void;
 };
 
 const Option = ({
   id,
-  name,
+  name = '',
   value,
   children,
   onChange,
   disabled,
+  validates,
   ...restProps
 }: OptionProps) => {
   const { selectedValue } = useRadioContext();
+  const formController = useForm(name, selectedValue);
+
   const optionId = id || `option-${name}-${value}`;
+  const isChecked = (formController?.value ?? selectedValue) === value;
+
+  const handleChange =
+    onChange ??
+    Object.values({ ...formController?.subscribe(validates) }).pop();
+
   return (
     <div {...restProps}>
       <input
@@ -82,9 +95,9 @@ const Option = ({
         id={optionId}
         name={name}
         value={value}
-        onChange={onChange}
         disabled={disabled}
-        checked={value === selectedValue}
+        defaultChecked={isChecked}
+        onChange={handleChange}
       />
       <label htmlFor={optionId}>{children}</label>
     </div>

--- a/src/components/common/RadioGroup/radioGroup.stories.tsx
+++ b/src/components/common/RadioGroup/radioGroup.stories.tsx
@@ -1,9 +1,12 @@
 import { ComponentStory, ComponentMeta } from '@storybook/react';
 import { useState } from 'react';
 
-import RadioGroup from '.';
-
-import StyledRadio from './radioGroup.styled';
+import StyledButton from '@components/common/Button/button.styled';
+import FlexBox from '@components/common/FlexBox';
+import StyledForm from '@components/common/Form/form.styled';
+import RadioGroup from '@components/common/RadioGroup';
+import StyledRadio from '@components/common/RadioGroup/radioGroup.styled';
+import Text from '@components/common/Text';
 
 export default {
   title: 'common/RadioGroup',
@@ -35,5 +38,59 @@ export const Default: ComponentStory<typeof RadioGroup> = () => {
         </StyledRadio.Option>
       ))}
     </StyledRadio.Group>
+  );
+};
+
+export const FormRadioGroup: ComponentStory<typeof RadioGroup> = () => {
+  const [formValues, setValues] = useState({});
+  const handleSubmit = (e, value) => {
+    setValues(value);
+  };
+
+  return (
+    <FlexBox
+      sx={{
+        flexDirection: 'column',
+        width: '100%',
+        gap: '1rem',
+      }}
+    >
+      <StyledForm onSubmit={handleSubmit} validationMode="onBlur">
+        <FlexBox
+          sx={{
+            flexDirection: 'column',
+            width: '100%',
+            gap: '1rem',
+          }}
+        >
+          <Text
+            variant="articleTitle"
+            sx={{
+              color: 'primary',
+            }}
+          >
+            체크아웃
+          </Text>
+          <Text variant="sectionDescription">설정 여부</Text>
+          <StyledRadio.Group name="check-out-setting" selectedValue="public">
+            <StyledRadio.Option value="public">공개</StyledRadio.Option>
+            <StyledRadio.Option value="private">비공개</StyledRadio.Option>
+          </StyledRadio.Group>
+          <Text variant="sectionDescription">인증 제출 여부</Text>
+          <StyledRadio.Group name="check-out-submission" selectedValue="public">
+            <StyledRadio.Option value="public">제출</StyledRadio.Option>
+            <StyledRadio.Option value="private">미제출</StyledRadio.Option>
+          </StyledRadio.Group>
+        </FlexBox>
+        <StyledButton type="submit" width="large" height="large">
+          스터디 생성
+        </StyledButton>
+      </StyledForm>
+      <FlexBox sx={{ flexDirection: 'column', gap: '1rem' }}>
+        {Object.keys(formValues).map((key) => (
+          <Text key={key}>{`${key} : ${formValues[key]}`}</Text>
+        ))}
+      </FlexBox>
+    </FlexBox>
   );
 };

--- a/src/components/common/RadioGroup/radioGroup.styled.tsx
+++ b/src/components/common/RadioGroup/radioGroup.styled.tsx
@@ -1,11 +1,12 @@
 import styled, { css } from 'styled-components';
 
 import RadioGroup from '@components/common/RadioGroup';
+import { typography } from '@styles/typography';
 
 const StyledRadioGroup = styled(RadioGroup)`
   display: flex;
   flex-direction: row;
-  width: 355px;
+  max-width: 355px;
   justify-content: space-between;
   align-items: center;
 `;
@@ -13,11 +14,11 @@ const StyledRadioGroup = styled(RadioGroup)`
 const CustomRadioButtonStyle = css`
   -webkit-appearance: none;
   appearance: none;
-  width: 32px;
-  height: 32px;
+  width: 2rem;
+  height: 2rem;
   margin: 0;
-  padding: 6px;
-  border: 2px solid #0000007f;
+  padding: 0.2rem;
+  border: 0.2rem solid #0000007f;
   border-radius: 50%;
   background-clip: content-box;
 
@@ -42,8 +43,8 @@ const StyledRadioOption = styled(RadioGroup.Option)`
   }
 
   label {
-    font-size: 17px;
-    padding: 10px;
+    ${typography.sectionDescription};
+    padding: 1rem;
   }
 `;
 


### PR DESCRIPTION
close #91

## ✨ 구현 내역
별도의 상태관리 로직을 가지고 있던 RadioGroup 컴포넌트가 Form 태그 하위에서 사용 될 때 RadioGroup의 값을 Form에서 일괄적으로 관리 할 수 있게 RadioGroup 내에 useForm을 적용하였습니다.

### 1. useFormContext & useForm
```tsx
export const useFormContext = () => {
  const context = useContext(FormContext);
 // if (!context) {
    // throw new Error(
    //   'useFormContext should be used within FormContext.Provider',
    // );
 // }
  return context;
};

const useForm = (name: string, initValue?: string): FormHookReturns => {
  const context = useFormContext();

  if (!context) return null;
  ...
}
```
- useForm을 Form 태그 하위가 아닌 곳에서도 사용할 수 있게 error를 throw 하지 않고 null 또는 context를 반환하도록 처리하였습니다.

### 2. RadioGroup.Option
```tsx
const Option = () => {
  const { selectedValue } = useRadioContext(); 
  const { value: formValue, subscribe, validationMode } = useForm(name, selectedValue) ?? {};

  const isChecked = (formValue ?? selectedValue) === value;
  const handleChange = onChange ?? subscribe(validates)[validationMode];

  return (
    <div>
      <input
        ...
        defaultChecked={isChecked}
        onChange={handleChange}
      />
      <label>{children}</label>
    </div>
  );
};
```
- selectedValue는 Form 하위에서 사용할 때는 초기값으로만 쓰이고 Form 에서 사용되지 않을 때는 [기존의 방식](https://github.com/Co-Studo/Co-Studo-front/blob/dev/src/components/common/RadioGroup/radioGroup.stories.tsx#L14)과 같이 **외부에서 주입되는 상태값**으로 쓰입니다.
- RadioGroup 에서는 onChange 이벤트 시 값을 컨트롤 하는게 정석이라고 생각해 이벤트를 onChange로 한정지었습니다. 

## 😭 고민 사항
### 코드의 가독성
```tsx
const {
  value: formValue,
  subscribe = () => {},
  validationMode = 'onChange',
} = useForm(name, selectedValue) ?? {};

const isChecked = (formValue ?? selectedValue) === value;
const handleChange = onChange ?? subscribe(validates)[validationMode];
```

useForm이 Form 태그의 하위가 아닐 시 null 을 반환하게 한 탓에
null 일 때의 타입 체크를 요리조리 피해서 코드를 짜다보니 위와 같은 코드가 만들어졌습니다....
짜고보니 이게 과연 가독성이 괜찮은 코드인지 고민이 됩니다...

```tsx
const formControl = useForm(name, selectedValue);
const isChecked = (formValue?.value ?? selectedValue) === value;
```

원래는 위 처럼 useForm을 formControl 이라는 변수로 받아서 옵셔널 체이닝으로 썼는데
무수한 물음표로 코드가 띠용?스러워지는 것 같아 물음표를 줄이다가 현재의 방식으로 수정하게 되었습니다...ㅠ

해당 부분의 가독성이 괜찮은지 아니면 개선이 필요할지 의견을 남겨주시면 감사하겠습니다!ㅠㅠ