### PR TITLE
[Hemdi] PageLayout - Main 분리, 레이아웃 타입 추가

### DIFF
--- a/src/components/common/PageLayout/index.tsx
+++ b/src/components/common/PageLayout/index.tsx
@@ -1,34 +1,23 @@
 import { FlexBox } from '@cos-ui/react';
 import { ReactNode } from 'react';
 
-type PageLayoutSX = {
-  width?: string;
-  height?: string;
-  backgroundColor?: string;
-};
-
 type PageLayoutProps = {
   children: ReactNode;
   size?: 'wide' | 'default';
-  sx?: PageLayoutSX;
 };
+
+const HEADER_HEIGHT = '6rem';
 
 const layoutSize = {
   wide: {
-    width: '100%',
-    height: '100%',
-    padding: '6rem',
+    maxWidth: 'none',
   },
   default: {
-    width: '100%',
-    height: '100%',
     maxWidth: '1270px',
-    padding: '6rem',
   },
 };
 
 const PageLayout = ({
-  sx,
   size = 'default',
   children,
   ...restProps
@@ -36,22 +25,16 @@ const PageLayout = ({
   <FlexBox
     as="main"
     sx={{
-      flexDirection: 'column',
-      alignItems: 'center',
       width: '100%',
-      mt: '6rem',
+      height: `calc(100vh - ${HEADER_HEIGHT})`,
+      m: `${HEADER_HEIGHT} auto 0`,
+      bgColor: 'white',
+      flexDirection: 'column',
+      ...layoutSize[size],
     }}
     {...restProps}
   >
-    <FlexBox
-      sx={{
-        flexDirection: 'column',
-        bgColor: 'white',
-        ...layoutSize[size],
-      }}
-    >
-      {children}
-    </FlexBox>
+    {children}
   </FlexBox>
 );
 

--- a/src/components/common/PageLayout/index.tsx
+++ b/src/components/common/PageLayout/index.tsx
@@ -3,34 +3,40 @@ import { ReactNode } from 'react';
 
 type PageLayoutProps = {
   children: ReactNode;
-  size?: 'wide' | 'default';
+  type?: 'default' | 'narrow' | 'wide';
 };
 
-const HEADER_HEIGHT = '6rem';
+export const LAYOUT_DEFAULT_PADDING = '6rem';
+const LAYOUT_DEFAULT_MAX_WIDTH = '1270px';
 
-const layoutSize = {
+const layoutStyles = {
+  default: {
+    maxWidth: LAYOUT_DEFAULT_MAX_WIDTH,
+    p: LAYOUT_DEFAULT_PADDING,
+  },
+  narrow: {
+    maxWidth: LAYOUT_DEFAULT_MAX_WIDTH,
+    py: LAYOUT_DEFAULT_PADDING,
+  },
   wide: {
     maxWidth: 'none',
-  },
-  default: {
-    maxWidth: '1270px',
+    py: LAYOUT_DEFAULT_PADDING,
   },
 };
 
 const PageLayout = ({
-  size = 'default',
+  type = 'default',
   children,
   ...restProps
 }: PageLayoutProps) => (
   <FlexBox
-    as="main"
     sx={{
-      width: '100%',
-      height: `calc(100vh - ${HEADER_HEIGHT})`,
-      m: `${HEADER_HEIGHT} auto 0`,
-      bgColor: 'white',
       flexDirection: 'column',
-      ...layoutSize[size],
+      width: '100%',
+      height: '100%',
+      bgColor: 'white',
+      m: `0 auto`,
+      ...layoutStyles[type],
     }}
     {...restProps}
   >

--- a/src/components/common/PageLayout/index.tsx
+++ b/src/components/common/PageLayout/index.tsx
@@ -1,25 +1,58 @@
+import { FlexBox } from '@cos-ui/react';
 import { ReactNode } from 'react';
 
-const PageLayout: React.FC<{ children: ReactNode; sx?: object }> = (props) => {
-  const { children, sx } = props;
+type PageLayoutSX = {
+  width?: string;
+  height?: string;
+  backgroundColor?: string;
+};
 
-  return (
-    <main
-      css={{
-        marginTop: '9rem',
-        marginLeft: '2rem',
-        marginRight: '2rem',
-        width: '100vw',
-        display: 'flex',
+type PageLayoutProps = {
+  children: ReactNode;
+  size?: 'wide' | 'default';
+  sx?: PageLayoutSX;
+};
+
+const layoutSize = {
+  wide: {
+    width: '100%',
+    height: '100%',
+    padding: '6rem',
+  },
+  default: {
+    width: '100%',
+    height: '100%',
+    maxWidth: '1270px',
+    padding: '6rem',
+  },
+};
+
+const PageLayout = ({
+  sx,
+  size = 'default',
+  children,
+  ...restProps
+}: PageLayoutProps) => (
+  <FlexBox
+    as="main"
+    sx={{
+      flexDirection: 'column',
+      alignItems: 'center',
+      width: '100%',
+      mt: '6rem',
+    }}
+    {...restProps}
+  >
+    <FlexBox
+      sx={{
         flexDirection: 'column',
-        justifyContent: 'center',
-        ...sx,
+        bgColor: 'white',
+        ...layoutSize[size],
       }}
-      {...props}
     >
       {children}
-    </main>
-  );
-};
+    </FlexBox>
+  </FlexBox>
+);
 
 export default PageLayout;

--- a/src/components/common/PageLayout/index.tsx
+++ b/src/components/common/PageLayout/index.tsx
@@ -2,8 +2,8 @@ import { FlexBox } from '@cos-ui/react';
 import { ReactNode } from 'react';
 
 type PageLayoutProps = {
-  children: ReactNode;
   type?: 'default' | 'narrow' | 'wide';
+  children: ReactNode;
 };
 
 const LAYOUT_DEFAULT_MAX_WIDTH = {
@@ -41,7 +41,7 @@ const PageLayout = ({
     sx={{
       flexDirection: 'column',
       width: '100%',
-      height: '100%',
+      minHeight: '100%',
       bgColor: 'white',
       m: `0 auto`,
       ...layoutStyles[type],

--- a/src/components/common/PageLayout/index.tsx
+++ b/src/components/common/PageLayout/index.tsx
@@ -6,21 +6,29 @@ type PageLayoutProps = {
   type?: 'default' | 'narrow' | 'wide';
 };
 
-export const LAYOUT_DEFAULT_PADDING = '6rem';
-const LAYOUT_DEFAULT_MAX_WIDTH = '1270px';
+const LAYOUT_DEFAULT_MAX_WIDTH = {
+  NARROW: '127rem',
+  WIDE: '144rem',
+};
+
+export const LAYOUT_DEFAULT_PADDING = {
+  VERTICAL: '6rem',
+  HORIZONTAL: '4.5rem',
+};
 
 const layoutStyles = {
   default: {
-    maxWidth: LAYOUT_DEFAULT_MAX_WIDTH,
-    p: LAYOUT_DEFAULT_PADDING,
+    maxWidth: LAYOUT_DEFAULT_MAX_WIDTH.NARROW,
+    px: LAYOUT_DEFAULT_PADDING.HORIZONTAL,
+    py: LAYOUT_DEFAULT_PADDING.VERTICAL,
   },
   narrow: {
-    maxWidth: LAYOUT_DEFAULT_MAX_WIDTH,
-    py: LAYOUT_DEFAULT_PADDING,
+    maxWidth: LAYOUT_DEFAULT_MAX_WIDTH.NARROW,
+    py: LAYOUT_DEFAULT_PADDING.VERTICAL,
   },
   wide: {
-    maxWidth: 'none',
-    py: LAYOUT_DEFAULT_PADDING,
+    maxWidth: LAYOUT_DEFAULT_MAX_WIDTH.WIDE,
+    py: LAYOUT_DEFAULT_PADDING.VERTICAL,
   },
 };
 

--- a/src/components/common/PageLayout/pageLayout.stories.tsx
+++ b/src/components/common/PageLayout/pageLayout.stories.tsx
@@ -1,3 +1,4 @@
+import { FlexBox, Text } from '@cos-ui/react';
 import { ComponentStory, ComponentMeta } from '@storybook/react';
 
 import PageLayout from '.';
@@ -9,5 +10,17 @@ export default {
 } as ComponentMeta<typeof PageLayout>;
 
 export const Default: ComponentStory<typeof PageLayout> = (args) => (
-  <PageLayout {...args} />
+  <PageLayout {...args}>
+    <FlexBox
+      sx={{
+        width: '100%',
+        height: '10rem',
+        bgColor: 'primary_light',
+        justifyContent: 'center',
+        alignItems: 'center',
+      }}
+    >
+      <Text variant="sectionTitle">Page Contents</Text>
+    </FlexBox>
+  </PageLayout>
 );

--- a/src/components/common/PageLayout/pageLayout.stories.tsx
+++ b/src/components/common/PageLayout/pageLayout.stories.tsx
@@ -13,11 +13,13 @@ export const Default: ComponentStory<typeof PageLayout> = (args) => (
   <PageLayout {...args}>
     <FlexBox
       sx={{
+        flexDirection: 'column',
         width: '100%',
-        height: '10rem',
+        height: '100%',
         bgColor: 'primary_light',
         justifyContent: 'center',
         alignItems: 'center',
+        py: '5rem',
       }}
     >
       <Text variant="sectionTitle">Page Contents</Text>

--- a/src/layouts/Header/index.tsx
+++ b/src/layouts/Header/index.tsx
@@ -4,6 +4,7 @@ import { css } from 'styled-components';
 
 import { useMe } from '@fbase/auth';
 import UserInfoCircle from '@layouts/Header/UserInfoCircle';
+import zIndex from '@styles/zindex';
 
 export const HEADER_HEIGHT = '6rem';
 
@@ -30,6 +31,7 @@ const Header = () => {
         top: 0;
         left: 0;
         padding: 1.5rem 2rem;
+        z-index: ${zIndex.header};
       `}
     >
       <h1

--- a/src/layouts/Header/index.tsx
+++ b/src/layouts/Header/index.tsx
@@ -5,6 +5,8 @@ import { css } from 'styled-components';
 import { useMe } from '@fbase/auth';
 import UserInfoCircle from '@layouts/Header/UserInfoCircle';
 
+export const HEADER_HEIGHT = '6rem';
+
 const Header = () => {
   const user = useMe();
   const navigate = useNavigate();
@@ -23,7 +25,7 @@ const Header = () => {
         box-shadow: 0 4px 10px ${({ theme }) => theme.palette.shadow_100},
           0 0 4px ${({ theme }) => theme.palette.shadow_500};
         background-color: ${({ theme }) => theme.palette.white};
-        height: 5.875rem;
+        height: ${HEADER_HEIGHT};
         position: fixed;
         top: 0;
         left: 0;

--- a/src/layouts/Layout.tsx
+++ b/src/layouts/Layout.tsx
@@ -1,11 +1,10 @@
-import { Outlet } from 'react-router-dom';
-
 import Header from '@layouts/Header';
+import Main from '@layouts/Main';
 
 const Layout = () => (
   <>
     <Header />
-    <Outlet />
+    <Main />
   </>
 );
 

--- a/src/layouts/Main/index.tsx
+++ b/src/layouts/Main/index.tsx
@@ -1,0 +1,17 @@
+import { Outlet } from 'react-router-dom';
+
+import { HEADER_HEIGHT } from '@layouts/Header';
+
+const mainStyle = {
+  width: '100%',
+  height: `calc(100vh - ${HEADER_HEIGHT})`,
+  marginTop: `${HEADER_HEIGHT}`,
+};
+
+const Main = () => (
+  <main css={mainStyle}>
+    <Outlet />
+  </main>
+);
+
+export default Main;

--- a/src/styles/zindex.tsx
+++ b/src/styles/zindex.tsx
@@ -1,0 +1,5 @@
+const zIndex = {
+  header: 100,
+};
+
+export default zIndex;


### PR DESCRIPTION
close #89 

## ✨ 구현 내역
### 1. Main 분리
[이전에 구현했던 PageLayout](https://github.com/Co-Studo/Co-Studo-front/pull/101) 에서 Main과 내부 Container 의 역할을 분리해야 한다는 의견을 수용하여 PageLayout에서 Main을 분리하였습니다.
- **Main(회색)** : Header의 Height 사이즈에 따라 Margin Top 과 Height 값 적용
- **PageLayout(흰색)** : Max-Width, 페이지 내부 여백(Padding), 가운데 정렬

### 2. PageLayout type 추가
이전 PageLayout 에서 size props 를 이용해 wide와 default 로 max-width 값을 제어하여 2개의 레이아웃 구분하였는데,
default size에 적용되어 있던 좌우 padding 값으로 인해 스터디 상세 페이지의 탭을 디자인 시안대로 구현하는데 문제가 있었습니다.

![스크린샷 2022-12-09 오전 5 05 17](https://user-images.githubusercontent.com/34249911/206556844-b8b51236-2245-4954-acf7-ddb8c8aa45ed.png)

이를 해결하기 위해 [해당 PR의 코멘트](https://github.com/Co-Studo/Co-Studo-front/pull/101#discussion_r1037071188)에 남긴대로 좌우 padding이 적용되지 않은 새로운 size type을 추가하게 되었습니다.
해당 속성의 네이밍 또한 size 에서 type으로 변경하였습니다.
(새롭게 추가 한 type의 네이밍을 wide의 반의어인 narrow를 사용하였는데...조금 더 나은 네이밍이 있다면 추천 받습니다...^-ㅠ))

### 3. PageLayout 스토리 코드 수정
PageLayout 의 타입별로 어떤 차이가 있는지 스토리북으로 명확히 확인하기 위해 스토리 컴포넌트 코드를 수정하였습니다.
