### PR TITLE
[Dony] Icon 컴포넌트 내부 styled 지정 경고, xSmall 사이즈 추가

### DIFF
--- a/src/assets/icons/lock.svg
+++ b/src/assets/icons/lock.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="-3.05 -0.6 20 20">
-  <g id="그룹_110" data-name="그룹 110" transform="translate(-236.052 -236.999)" opacity="0.5">
+  <g id="그룹_110" data-name="그룹 110" transform="translate(-236.052 -236.999)">
     <rect id="사각형_19" data-name="사각형 19" width="12.957" height="10.749" transform="translate(236.521 244.575)" fill="none"  stroke-linecap="round" stroke-linejoin="round" stroke-width="0.938"/>
     <path id="패스_8" data-name="패스 8" d="M11.1,6.971V4.649a4.157,4.157,0,1,0-8.314,0V6.971" transform="translate(236.052 237)" fill="none"  stroke-linecap="round" stroke-linejoin="round" stroke-width="0.985"/>
     <path id="패스_9" data-name="패스 9" d="M5.595,14.167A1.353,1.353,0,1,1,6.948,15.52a1.353,1.353,0,0,1-1.353-1.353" transform="translate(236.052 236.499)"/>

--- a/src/components/common/Icon/index.tsx
+++ b/src/components/common/Icon/index.tsx
@@ -3,11 +3,14 @@ import styled from 'styled-components';
 
 import { icon, IconName } from '@assets/icons';
 
-type IconProps = {
-  iconName: IconName;
+type StyledIconProps = {
   size?: keyof typeof iconSizes;
   color?: keyof Palette;
 };
+
+interface IconProps extends StyledIconProps {
+  iconName: IconName;
+}
 
 const iconSizes = {
   xSmall: '1.5rem',
@@ -17,17 +20,15 @@ const iconSizes = {
   xLarge: '3.5rem',
 };
 
-const Icon = ({ iconName, size = 'medium', color }: IconProps) => {
-  const IconComponent = icon[iconName];
+const StyledIcon = styled(icon.bell)<StyledIconProps>`
+  width: ${({ size = 'medium' }) => iconSizes[size]};
+  height: auto;
+  fill: ${({ theme, color = 'primary' }) => theme.palette[color]};
+  stroke: ${({ theme, color = 'primary' }) => theme.palette[color]};
+`;
 
-  const StyledIcon = styled(IconComponent)`
-    width: ${iconSizes[size]};
-    height: auto;
-    fill: ${({ theme }) => theme.palette[color || 'primary']};
-    stroke: ${({ theme }) => theme.palette[color || 'primary']};
-  `;
-
-  return <StyledIcon />;
-};
+const Icon = ({ iconName, ...restProps }: IconProps) => (
+  <StyledIcon as={icon[iconName]} {...restProps} />
+);
 
 export default Icon;

--- a/src/components/common/Icon/index.tsx
+++ b/src/components/common/Icon/index.tsx
@@ -10,6 +10,7 @@ type IconProps = {
 };
 
 const iconSizes = {
+  xSmall: '1.5rem',
   small: '2rem',
   medium: '2.5rem',
   large: '3rem',


### PR DESCRIPTION
close #107 

## 수정 사항
- styled 컴포넌트 동적 생성 경고 수정
- svg 내에 opacity 코드 삭제
- xSmall 사이즈 추가

## Reference
#107 이슈에 Reference 참고